### PR TITLE
drivers: i2c: gd32: add GD32F50X I2C driver support

### DIFF
--- a/boards/gd/gd32f503v_eval/gd32f503v_eval-pinctrl.dtsi
+++ b/boards/gd/gd32f503v_eval/gd32f503v_eval-pinctrl.dtsi
@@ -22,6 +22,13 @@
 		};
 	};
 
+	i2c1_default: i2c1_default {
+		group1 {
+			pinmux = <I2C1_SCL_PB10>, <I2C1_SDA_PB11>;
+			drive-open-drain;
+		};
+	};
+
 	spi0_default: spi0_default {
 		group1 {
 			pinmux = <SPI0_SCK_PA5>, <SPI0_MOSI_PA7>,

--- a/boards/gd/gd32f503v_eval/gd32f503v_eval.dts
+++ b/boards/gd/gd32f503v_eval/gd32f503v_eval.dts
@@ -71,10 +71,24 @@
 	status = "okay";
 };
 
+&dma0 {
+	status = "okay";
+};
+
+&dma1 {
+	status = "okay";
+};
+
+&dmamux {
+	status = "okay";
+};
+
 &i2c0 {
 	status = "okay";
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
+	dmas = <&dmamux 0 16 0x480>, <&dmamux 1 17 0x440>;
+	dma-names = "rx", "tx";
 	clock-frequency = <100000>;
 	eeprom0: eeprom@50 {
 		compatible = "atmel,at24";
@@ -85,6 +99,15 @@
 		address-width = <8>;
 		timeout = <5>;
 	};
+};
+
+&i2c1 {
+	status = "disabled";
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-names = "default";
+	dmas = <&dmamux 2 18 0x480>, <&dmamux 3 19 0x440>;
+	dma-names = "rx", "tx";
+	clock-frequency = <100000>;
 };
 
 &spi0 {

--- a/boards/gd/scripts/gd32_peripheral_matrix.yaml
+++ b/boards/gd/scripts/gd32_peripheral_matrix.yaml
@@ -69,6 +69,7 @@ test_groups:
       - gd32f450i_eval
       - gd32f470i_eval
       - gd32f527i_eval
+      - gd32f503v_eval
 
   # 组6: Shell 功能测试
   shell_capable:

--- a/drivers/dma/CMakeLists.txt
+++ b/drivers/dma/CMakeLists.txt
@@ -29,6 +29,7 @@ zephyr_library_sources_ifdef(CONFIG_DMA_INTEL_ADSP_HDA_LINK_OUT dma_intel_adsp_h
 zephyr_library_sources_ifdef(CONFIG_DMA_INTEL_ADSP_GPDMA	dma_intel_adsp_gpdma.c dma_dw_common.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_INTEL_LPSS      dma_intel_lpss.c dma_dw_common.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_GD32		dma_gd32.c)
+zephyr_library_sources_ifdef(CONFIG_DMAMUX_GD32		dmamux_gd32.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_ESP32		dma_esp32_gdma.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_MCHP_XEC	dma_mchp_xec.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_XMC4XXX		dma_xmc4xxx.c)

--- a/drivers/dma/Kconfig.gd32
+++ b/drivers/dma/Kconfig.gd32
@@ -8,3 +8,21 @@ config DMA_GD32
 	select USE_GD32_DMA
 	help
 	  DMA driver for GigaDevice GD32 series MCUs.
+
+config DMAMUX_GD32
+	bool "GigaDevice GD32 DMAMUX driver"
+	default y
+	depends on DT_HAS_GD_GD32_DMAMUX_ENABLED
+	depends on DMA_GD32
+	help
+	  DMAMUX driver for GigaDevice GD32 series MCUs with DMA request
+	  multiplexer (e.g., GD32F50x). The DMAMUX routes peripheral DMA
+	  requests to DMA channels.
+
+config DMAMUX_GD32_INIT_PRIORITY
+	int "GD32 DMAMUX init priority"
+	depends on DMAMUX_GD32
+	default 41
+	help
+	  DMAMUX driver device must be initialized after the DMA driver.
+	  Default 41 is higher than CONFIG_DMA_INIT_PRIORITY (default 40).

--- a/drivers/dma/dmamux_gd32.c
+++ b/drivers/dma/dmamux_gd32.c
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2025 GigaDevice Semiconductor Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @brief GD32 DMAMUX driver
+ *
+ * The DMAMUX is a request multiplexer that routes peripheral DMA requests
+ * to DMA channels. This driver acts as a proxy between peripherals and
+ * the underlying DMA controller, setting the request ID in the DMAMUX
+ * hardware before forwarding calls to the real DMA.
+ *
+ * Architecture:
+ *   Peripheral -> DMAMUX -> DMA Controller
+ *
+ * The DMAMUX channels map to underlying DMA channels:
+ *   - Channel 0-6:  DMA0 channel 0-6
+ *   - Channel 7-11: DMA1 channel 0-4
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/gd32.h>
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/reset.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
+
+#include <gd32_dma.h>
+
+LOG_MODULE_REGISTER(dmamux_gd32, CONFIG_DMA_LOG_LEVEL);
+
+#define DT_DRV_COMPAT gd_gd32_dmamux
+
+/*
+ * Use HAL register definitions from gd32f50x_dma.h:
+ *   DMAMUX_RM_CHxCFG        - channel config registers (offset 0x00 + ch*4)
+ *   DMAMUX_RM_INTF          - interrupt flag register (offset 0x80)
+ *   DMAMUX_RM_INTC          - interrupt clear register (offset 0x84)
+ *   DMAMUX_RM_CHXCFG_MUXID  - request ID field [7:0]
+ *   DMAMUX_RM_CHXCFG_SOIE   - sync overrun interrupt enable
+ *   DMAMUX_RM_CHXCFG_EVGEN  - event generation enable
+ *   DMAMUX_RM_CHXCFG_SYNCEN - sync enable
+ *
+ * Access macro for channel config register by base address and channel number
+ */
+#define DMAMUX_CHxCFG(base, ch) REG32((base) + (ch) * 4U)
+#define DMAMUX_INTF(base)       REG32((base) + 0x80U)
+#define DMAMUX_INTC(base)       REG32((base) + 0x84U)
+
+/* DMA0 has 7 channels (0-6), DMA1 has 5 channels (0-4) */
+#define DMA0_CHANNEL_COUNT 7
+#define DMA1_CHANNEL_COUNT 5
+#define MAX_DMAMUX_CHANNELS (DMA0_CHANNEL_COUNT + DMA1_CHANNEL_COUNT)
+
+/* Each DMAMUX channel maps to a specific DMA controller and channel */
+struct dmamux_gd32_channel_map {
+	const struct device *dma_dev;
+	uint8_t dma_channel;
+};
+
+struct dmamux_gd32_config {
+	uint32_t base;
+	uint8_t channel_count;
+	uint8_t generator_count;
+	uint16_t request_count;
+	uint16_t clkid;
+	const struct dmamux_gd32_channel_map *channel_map;
+};
+
+struct dmamux_gd32_data {
+	/* DMA context for channel allocation (required by dma_request_channel) */
+	struct dma_context ctx;
+	/* Per-channel callback info */
+	dma_callback_t callbacks[MAX_DMAMUX_CHANNELS];
+	void *user_data[MAX_DMAMUX_CHANNELS];
+};
+
+/**
+ * @brief Set the request ID for a DMAMUX channel
+ */
+static void dmamux_gd32_set_request(const struct dmamux_gd32_config *cfg,
+				    uint32_t channel, uint32_t request_id)
+{
+	uint32_t reg_val;
+
+	reg_val = DMAMUX_CHxCFG(cfg->base, channel);
+	reg_val &= ~BITS(0, 7);
+	reg_val |= (request_id & BITS(0, 7));
+	DMAMUX_CHxCFG(cfg->base, channel) = reg_val;
+
+	LOG_DBG("DMAMUX ch%d: set request ID %d (reg=0x%08x)",
+		channel, request_id, DMAMUX_CHxCFG(cfg->base, channel));
+}
+
+/**
+ * @brief DMA callback wrapper to route to user callback
+ */
+static void dmamux_gd32_dma_callback(const struct device *dma_dev, void *arg,
+				     uint32_t channel, int status)
+{
+	const struct device *dev = arg;
+	struct dmamux_gd32_data *data = dev->data;
+	const struct dmamux_gd32_config *cfg = dev->config;
+
+	/* Find the DMAMUX channel corresponding to this DMA callback */
+	for (uint32_t i = 0; i < cfg->channel_count; i++) {
+		if (cfg->channel_map[i].dma_dev == dma_dev &&
+		    cfg->channel_map[i].dma_channel == channel) {
+			if (data->callbacks[i]) {
+				data->callbacks[i](dev, data->user_data[i], i, status);
+			}
+			return;
+		}
+	}
+
+	LOG_WRN("DMAMUX: Unexpected DMA callback from %s ch%d",
+		dma_dev->name, channel);
+}
+
+static int dmamux_gd32_configure(const struct device *dev, uint32_t channel,
+				 struct dma_config *config)
+{
+	const struct dmamux_gd32_config *cfg = dev->config;
+	struct dmamux_gd32_data *data = dev->data;
+	const struct dmamux_gd32_channel_map *map;
+	uint32_t request_id;
+	int ret;
+
+	if (channel >= cfg->channel_count) {
+		LOG_ERR("DMAMUX channel %d out of range (max %d)",
+			channel, cfg->channel_count - 1);
+		return -EINVAL;
+	}
+
+	/* Request ID is passed via dma_slot */
+	request_id = config->dma_slot;
+	if (request_id > cfg->request_count) {
+		LOG_ERR("DMAMUX request ID %d out of range (max %d)",
+			request_id, cfg->request_count);
+		return -EINVAL;
+	}
+
+	map = &cfg->channel_map[channel];
+	if (!device_is_ready(map->dma_dev)) {
+		LOG_ERR("DMAMUX: DMA device %s not ready", map->dma_dev->name);
+		return -ENODEV;
+	}
+
+	/* Store user callback and wrap it */
+	data->callbacks[channel] = config->dma_callback;
+	data->user_data[channel] = config->user_data;
+
+	/* Replace callback with our wrapper */
+	config->dma_callback = dmamux_gd32_dma_callback;
+	config->user_data = (void *)dev;
+
+	/* Configure the underlying DMA channel */
+	ret = dma_config(map->dma_dev, map->dma_channel, config);
+	if (ret < 0) {
+		LOG_ERR("DMAMUX: Failed to configure DMA %s ch%d: %d",
+			map->dma_dev->name, map->dma_channel, ret);
+		return ret;
+	}
+
+	/* Set the request ID in DMAMUX hardware */
+	dmamux_gd32_set_request(cfg, channel, request_id);
+
+	LOG_DBG("DMAMUX ch%d configured: req=%d -> DMA %s ch%d",
+		channel, request_id, map->dma_dev->name, map->dma_channel);
+
+	return 0;
+}
+
+static int dmamux_gd32_reload(const struct device *dev, uint32_t channel,
+			      uint32_t src, uint32_t dst, size_t size)
+{
+	const struct dmamux_gd32_config *cfg = dev->config;
+	const struct dmamux_gd32_channel_map *map;
+
+	if (channel >= cfg->channel_count) {
+		return -EINVAL;
+	}
+
+	map = &cfg->channel_map[channel];
+	return dma_reload(map->dma_dev, map->dma_channel, src, dst, size);
+}
+
+static int dmamux_gd32_start(const struct device *dev, uint32_t channel)
+{
+	const struct dmamux_gd32_config *cfg = dev->config;
+	const struct dmamux_gd32_channel_map *map;
+
+	if (channel >= cfg->channel_count) {
+		return -EINVAL;
+	}
+
+	map = &cfg->channel_map[channel];
+
+	LOG_DBG("DMAMUX ch%d start -> DMA %s ch%d",
+		channel, map->dma_dev->name, map->dma_channel);
+
+	return dma_start(map->dma_dev, map->dma_channel);
+}
+
+static int dmamux_gd32_stop(const struct device *dev, uint32_t channel)
+{
+	const struct dmamux_gd32_config *cfg = dev->config;
+	const struct dmamux_gd32_channel_map *map;
+
+	if (channel >= cfg->channel_count) {
+		return -EINVAL;
+	}
+
+	map = &cfg->channel_map[channel];
+	return dma_stop(map->dma_dev, map->dma_channel);
+}
+
+static int dmamux_gd32_get_status(const struct device *dev, uint32_t channel,
+				  struct dma_status *stat)
+{
+	const struct dmamux_gd32_config *cfg = dev->config;
+	const struct dmamux_gd32_channel_map *map;
+
+	if (channel >= cfg->channel_count) {
+		return -EINVAL;
+	}
+
+	map = &cfg->channel_map[channel];
+	return dma_get_status(map->dma_dev, map->dma_channel, stat);
+}
+
+static bool dmamux_gd32_chan_filter(const struct device *dev, int channel,
+				    void *filter_param)
+{
+	const struct dmamux_gd32_config *cfg = dev->config;
+	uint32_t filter;
+
+	if (!filter_param) {
+		return false;
+	}
+
+	filter = *((uint32_t *)filter_param);
+
+	if (channel >= cfg->channel_count) {
+		return false;
+	}
+
+	return (filter & BIT(channel)) != 0;
+}
+
+static int dmamux_gd32_init(const struct device *dev)
+{
+	const struct dmamux_gd32_config *cfg = dev->config;
+	int ret;
+
+	/* Enable DMAMUX clock */
+	ret = clock_control_on(GD32_CLOCK_CONTROLLER,
+			       (clock_control_subsys_t)&cfg->clkid);
+	if (ret < 0) {
+		LOG_ERR("Failed to enable DMAMUX clock: %d", ret);
+		return ret;
+	}
+
+	/* Clear all channel configurations */
+	for (uint32_t i = 0; i < cfg->channel_count; i++) {
+		DMAMUX_CHxCFG(cfg->base, i) = 0;
+	}
+
+	/* Clear interrupt flags */
+	DMAMUX_INTC(cfg->base) = 0xFFFFFFFF;
+
+	/* Verify DMA controllers are ready */
+	for (uint32_t i = 0; i < cfg->channel_count; i++) {
+		if (!device_is_ready(cfg->channel_map[i].dma_dev)) {
+			LOG_ERR("DMAMUX: DMA device for channel %d not ready", i);
+			return -ENODEV;
+		}
+	}
+
+	LOG_INF("DMAMUX initialized: %d channels, %d requests",
+		cfg->channel_count, cfg->request_count);
+
+	return 0;
+}
+
+static DEVICE_API(dma, dmamux_gd32_api) = {
+	.config = dmamux_gd32_configure,
+	.reload = dmamux_gd32_reload,
+	.start = dmamux_gd32_start,
+	.stop = dmamux_gd32_stop,
+	.get_status = dmamux_gd32_get_status,
+	.chan_filter = dmamux_gd32_chan_filter,
+};
+
+/*
+ * Channel map generation macros
+ *
+ * Maps DMAMUX channels to underlying DMA controllers:
+ *   DMAMUX ch0-6  -> DMA0 ch0-6
+ *   DMAMUX ch7-11 -> DMA1 ch0-4
+ */
+
+#define DMAMUX_DMA0_DEV DEVICE_DT_GET_OR_NULL(DT_NODELABEL(dma0))
+#define DMAMUX_DMA1_DEV DEVICE_DT_GET_OR_NULL(DT_NODELABEL(dma1))
+
+/* LISTIFY passes (index, ...) to the callback, so we need to accept extra args */
+#define DMAMUX_CHANNEL_MAP_ENTRY(ch, ...)				\
+	{								\
+		.dma_dev = ((ch) < DMA0_CHANNEL_COUNT) ?		\
+			   DMAMUX_DMA0_DEV : DMAMUX_DMA1_DEV,		\
+		.dma_channel = ((ch) < DMA0_CHANNEL_COUNT) ?		\
+			       (ch) : ((ch) - DMA0_CHANNEL_COUNT),	\
+	}
+
+#define DMAMUX_CHANNEL_MAP(n)						\
+	static const struct dmamux_gd32_channel_map			\
+		dmamux_gd32_channel_map_##n[] = {			\
+		LISTIFY(DT_INST_PROP(n, dma_channels),			\
+			DMAMUX_CHANNEL_MAP_ENTRY, (,))			\
+	}
+
+#define DMAMUX_GD32_INIT(n)						\
+	DMAMUX_CHANNEL_MAP(n);						\
+									\
+	static const struct dmamux_gd32_config dmamux_gd32_cfg_##n = {	\
+		.base = DT_INST_REG_ADDR(n),				\
+		.channel_count = DT_INST_PROP(n, dma_channels),		\
+		.generator_count = DT_INST_PROP_OR(n, dma_generators, 0),\
+		.request_count = DT_INST_PROP(n, dma_requests),		\
+		.clkid = DT_INST_CLOCKS_CELL(n, id),			\
+		.channel_map = dmamux_gd32_channel_map_##n,		\
+	};								\
+									\
+	ATOMIC_DEFINE(dmamux_gd32_atomic_##n,				\
+		      DT_INST_PROP(n, dma_channels));			\
+									\
+	static struct dmamux_gd32_data dmamux_gd32_data_##n = {		\
+		.ctx = {						\
+			.magic = DMA_MAGIC,				\
+			.atomic = dmamux_gd32_atomic_##n,		\
+			.dma_channels = DT_INST_PROP(n, dma_channels),	\
+		},							\
+	};								\
+									\
+	DEVICE_DT_INST_DEFINE(n, dmamux_gd32_init, NULL,			\
+			      &dmamux_gd32_data_##n,			\
+			      &dmamux_gd32_cfg_##n,			\
+			      PRE_KERNEL_1,				\
+			      CONFIG_DMAMUX_GD32_INIT_PRIORITY,		\
+			      &dmamux_gd32_api);
+
+DT_INST_FOREACH_STATUS_OKAY(DMAMUX_GD32_INIT)

--- a/drivers/i2c/Kconfig.gd32
+++ b/drivers/i2c/Kconfig.gd32
@@ -66,22 +66,21 @@ config I2C_GD32_DMA
 if I2C_GD32_DMA
 
 config I2C_GD32_DMA_THRESHOLD
-	int "DMA transfer threshold"
-	default 16
-	range 4 255
+	int "DMA transfer threshold (bytes)"
+	default 8
 	help
 	  Minimum transfer size (in bytes) to use DMA instead of PIO mode.
 	  Transfers smaller than this threshold will use PIO mode.
-	  Larger values reduce DMA setup overhead for small transfers.
-	  Default of 16 bytes provides good balance for most applications.
+	  Note: valid values are from 1 to 255 (bytes). Default is 8.
+
 
 config I2C_GD32_DMA_TIMEOUT
 	int "DMA transfer timeout (ms)"
-	default 1000
-	range 100 10000
+	default 500
 	help
-	  Timeout in milliseconds for DMA transfers.
-	  If a DMA transfer does not complete within this time,
-	  it will be considered failed.
+	  Timeout in milliseconds for DMA transfers. If a transfer does not
+	  complete within this time, the driver falls back to PIO mode.
+	  Note: valid values are from 100 to 10000 (milliseconds). Default is 500.
+
 
 endif # I2C_GD32_DMA

--- a/drivers/i2c/i2c_gd32_v2.c
+++ b/drivers/i2c/i2c_gd32_v2.c
@@ -987,7 +987,7 @@ int i2c_gd32_configure_gd(const struct device *dev, uint32_t dev_config)
 {
 	struct i2c_gd32_data *data = dev->data;
 	const struct i2c_gd32_config *cfg = dev->config;
-	uint32_t pclk1, freq;
+	uint32_t pclk1;
 	int err = 0;
 
 	k_sem_take(&data->bus_mutex, K_FOREVER);

--- a/dts/arm/gd/gd32f50x/gd32f50x.dtsi
+++ b/dts/arm/gd/gd32f50x/gd32f50x.dtsi
@@ -96,7 +96,7 @@
 		};
 
 		i2c0: i2c@40005400 {
-			compatible = "gd,gd32-i2c";
+			compatible = "gd,gd32-i2c-v2";
 			reg = <0x40005400 0x400>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -109,7 +109,7 @@
 		};
 
 		i2c1: i2c@40005800 {
-			compatible = "gd,gd32-i2c";
+			compatible = "gd,gd32-i2c-v2";
 			reg = <0x40005800 0x400>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/gd/gd32f50x/gd32f50x.dtsi
+++ b/dts/arm/gd/gd32f50x/gd32f50x.dtsi
@@ -237,6 +237,40 @@
 				status = "disabled";
 			};
 		};
+
+		dma0: dma@40020000 {
+			compatible = "gd,gd32-dma";
+			reg = <0x40020000 0x400>;
+			interrupts = <11 0>, <12 0>, <13 0>, <14 0>,
+				     <15 0>, <16 0>, <17 0>;
+			clocks = <&cctl GD32_CLOCK_DMA0>;
+			dma-channels = <7>;
+			gd,mem2mem;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		dma1: dma@40020400 {
+			compatible = "gd,gd32-dma";
+			reg = <0x40020400 0x400>;
+			interrupts = <56 0>, <57 0>, <58 0>, <59 0>, <60 0>;
+			clocks = <&cctl GD32_CLOCK_DMA1>;
+			dma-channels = <5>;
+			gd,mem2mem;
+			#dma-cells = <2>;
+			status = "disabled";
+		};
+
+		dmamux: dmamux@40020800 {
+			compatible = "gd,gd32-dmamux";
+			reg = <0x40020800 0x400>;
+			#dma-cells = <3>;
+			dma-channels = <12>;
+			dma-generators = <4>;
+			dma-requests = <108>;
+			clocks = <&cctl GD32_CLOCK_DMAMUX>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/dts/bindings/dma/gd,gd32-dmamux.yaml
+++ b/dts/bindings/dma/gd,gd32-dmamux.yaml
@@ -1,0 +1,101 @@
+# Copyright (c) 2025 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  GD32 DMAMUX controller
+
+  GD32 MCUs with DMAMUX (DMA request multiplexer) route peripheral request
+  lines to DMA channels. This binding is for MCUs like GD32F50x that have
+  a standalone DMAMUX peripheral.
+
+  The DMAMUX acts as a proxy for the underlying DMA controller. Peripherals
+  reference the DMAMUX rather than the DMA controller directly.
+
+  Clients connected to the DMAMUX must use a 3-cell DMA specifier:
+    1. channel: DMAMUX output channel number (0 .. dma-channels-1)
+    2. slot: DMAMUX request line ID (peripheral request selection)
+    3. channel-config: A 32-bit mask specifying the DMA channel configuration
+       - bit 6-7:   Direction (see dma.h)
+                    0x0: MEMORY to MEMORY
+                    0x1: MEMORY to PERIPH
+                    0x2: PERIPH to MEMORY
+                    0x3: reserved
+       - bit 9:     Peripheral address increment
+                    0x0: no address increment between transfers
+                    0x1: increment address between transfers
+       - bit 10:    Memory address increment
+                    0x0: no address increment between transfers
+                    0x1: increment address between transfers
+       - bit 11-12: Peripheral data width
+                    0x0: Byte (8 bits)
+                    0x1: Half-word (16 bits)
+                    0x2: Word (32 bits)
+                    0x3: reserved
+       - bit 13-14: Memory data width
+                    0x0: Byte (8 bits)
+                    0x1: Half-word (16 bits)
+                    0x2: Word (32 bits)
+                    0x3: reserved
+       - bit 16-17: Priority level
+                    0x0: low
+                    0x1: medium
+                    0x2: high
+                    0x3: very high
+
+  Example for GD32F50x:
+
+    dmamux: dmamux@40020800 {
+        compatible = "gd,gd32-dmamux";
+        reg = <0x40020800 0x400>;
+        #dma-cells = <3>;
+        dma-channels = <12>;
+        dma-generators = <4>;
+        dma-requests = <108>;
+        clocks = <&cctl GD32_CLOCK_DMAMUX>;
+        status = "disabled";
+    };
+
+  Example I2C client:
+
+    &i2c0 {
+        status = "okay";
+        dmas = <&dmamux 0 GD32_DMA_REQ_I2C0_RX 0x00000000>,
+               <&dmamux 1 GD32_DMA_REQ_I2C0_TX 0x00000000>;
+        dma-names = "rx", "tx";
+    };
+
+compatible: "gd,gd32-dmamux"
+
+include: dmamux-controller.yaml
+
+properties:
+  reg:
+    required: true
+
+  clocks:
+    required: true
+
+  "#dma-cells":
+    const: 3
+
+  dma-channels:
+    required: true
+    description: |
+      Total number of DMAMUX output channels.
+      For GD32F50x: 12 channels (DMA0 CH0-6 + DMA1 CH0-4)
+
+  dma-generators:
+    description: |
+      Number of request generators supported.
+      For GD32F50x: 4 generators
+
+  dma-requests:
+    required: true
+    description: |
+      Number of peripheral request inputs.
+      For GD32F50x: 108 request lines
+
+dma-cells:
+  - channel
+  - slot
+  - config

--- a/modules/hal_gigadevice/CMakeLists.txt
+++ b/modules/hal_gigadevice/CMakeLists.txt
@@ -88,7 +88,7 @@ zephyr_library_sources_ifdef(CONFIG_USE_GD32_FMC      ${gd32_std_src_dir}/${CONF
 zephyr_library_sources_ifdef(CONFIG_USE_GD32_FWDGT    ${gd32_std_src_dir}/${CONFIG_SOC_SERIES}_fwdgt.c)
 zephyr_library_sources_ifdef(CONFIG_USE_GD32_GPIO     ${gd32_std_src_dir}/${CONFIG_SOC_SERIES}_gpio.c)
 zephyr_library_sources_ifdef(CONFIG_USE_GD32_I2C_V1   ${gd32_std_src_dir}/${CONFIG_SOC_SERIES}_i2c.c)
-zephyr_library_sources_ifdef(CONFIG_USE_GD32_I2C_V2   ${gd32_std_src_dir}/${CONFIG_SOC_SERIES}_i2c_add.c)
+zephyr_library_sources_ifdef(CONFIG_USE_GD32_I2C_V2   ${gd32_std_src_dir}/${CONFIG_SOC_SERIES}_i2c.c)
 zephyr_library_sources_ifdef(CONFIG_USE_GD32_I2C_V3   ${gd32_std_src_dir}/${CONFIG_SOC_SERIES}_i2c_add.c)
 zephyr_library_sources_ifdef(CONFIG_USE_GD32_I2C_V3   ${gd32_std_src_dir}/${CONFIG_SOC_SERIES}_i2c.c)
 zephyr_library_sources_ifdef(CONFIG_USE_GD32_IPA      ${gd32_std_src_dir}/${CONFIG_SOC_SERIES}_ipa.c)


### PR DESCRIPTION
GD32F50X series uses I2C HAL API (i2c_* functions and I2C_CTL0/I2C_STAT registers) instead of ADD IP variants.

Update i2c_gd32_v2 driver and hal_gigadevice build configuration to support GD32F50X with API.