### PR TITLE
gd32f503: enhance drivers and dma support

### DIFF
--- a/boards/gd/gd32f503v_eval/gd32f503v_eval.dts
+++ b/boards/gd/gd32f503v_eval/gd32f503v_eval.dts
@@ -114,8 +114,9 @@
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
-	cs-gpios = <&gpioa 8 GPIO_ACTIVE_LOW>;
-
+	cs-gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;
+	dmas = <&dmamux 5 10 0x480>, <&dmamux 6 11 0x440>;
+	dma-names = "rx", "tx";
 	nor_flash: gd25q16@0 {
 		compatible = "jedec,spi-nor";
 		size = <0x1000000>;
@@ -131,4 +132,6 @@
 	current-speed = <115200>;
 	pinctrl-0 = <&usart0_default>;
 	pinctrl-names = "default";
+	dmas = <&dmamux 0 20 0x480>, <&dmamux 1 21 0x440>;
+	dma-names = "rx", "tx";
 };

--- a/boards/gd/scripts/gd32_peripheral_matrix.yaml
+++ b/boards/gd/scripts/gd32_peripheral_matrix.yaml
@@ -47,6 +47,7 @@ test_groups:
       - gd32f450z_eval
       - gd32f470i_eval
       - gd32f527i_eval
+      - gd32f503v_eval
 
   # 组4: SPI Flash测试（只测试有板级配置的）
   spi_flash:
@@ -58,6 +59,7 @@ test_groups:
       - gd32f450i_eval
       - gd32f470i_eval
       - gd32f527i_eval
+      - gd32f503v_eval
 
   # 组5: EEPROM测试（只测试有板级配置的）
   eeprom:
@@ -87,3 +89,4 @@ test_groups:
       - gd32f527i_eval
       - gd32l233r_eval
       - gd32vf103v_eval
+      - gd32f503v_eval

--- a/drivers/serial/usart_gd32.c
+++ b/drivers/serial/usart_gd32.c
@@ -36,19 +36,41 @@ LOG_MODULE_REGISTER(usart_gd32, CONFIG_UART_LOG_LEVEL);
 #define USART_DATA_REG(reg) ((reg) + 0x04)
 #define USART_CTL2_REG(reg) ((reg) + 0x14)
 
-/* DMA Initialization Macros */
+/*
+ * DMA Initialization Macros with DMAMUX support
+ *
+ * DMA cell mapping based on binding type:
+ * - gd,gd32-dma (3 cells): channel, slot, config
+ * - gd,gd32-dma-v1 (4 cells): channel, slot, config, fifo_threshold
+ * - gd,gd32-dmamux (3 cells): channel, slot, config
+ *
+ * Both gd,gd32-dma-v1 and gd,gd32-dmamux have 'slot' cell.
+ * Only gd,gd32-dma-v1 has 'fifo_threshold' cell.
+ */
+#define DMA_IS_V1(idx, dir) \
+	DT_NODE_HAS_COMPAT(DT_INST_DMAS_CTLR_BY_NAME(idx, dir), gd_gd32_dma_v1)
+
+#define DMA_IS_DMAMUX(idx, dir) \
+	DT_NODE_HAS_COMPAT(DT_INST_DMAS_CTLR_BY_NAME(idx, dir), gd_gd32_dmamux)
+
+/* Get slot value: try v1 first, then dmamux, then standard dma, default to 0 */
+#define DMA_GET_SLOT(idx, dir) \
+	COND_CODE_1(DMA_IS_V1(idx, dir), \
+		(DT_INST_DMAS_CELL_BY_NAME(idx, dir, slot)), \
+		(COND_CODE_1(DMA_IS_DMAMUX(idx, dir), \
+			(DT_INST_DMAS_CELL_BY_NAME(idx, dir, slot)), \
+			(COND_CODE_1(DT_INST_NODE_HAS_PROP(idx, dmas), \
+				(DT_INST_DMAS_CELL_BY_NAME(idx, dir, slot)), (0))))))
+
 #define USART_DMA_INITIALIZER(idx, dir)                                       \
 	{                                                                      \
 		.dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(idx, dir)),         \
 		.channel = DT_INST_DMAS_CELL_BY_NAME(idx, dir, channel),           \
-		.slot = COND_CODE_1(                                               \
-			DT_HAS_COMPAT_STATUS_OKAY(gd_gd32_dma_v1),                     \
-			(DT_INST_DMAS_CELL_BY_NAME(idx, dir, slot)), (0)),             \
+		.slot = DMA_GET_SLOT(idx, dir),                                    \
 		.config = DT_INST_DMAS_CELL_BY_NAME(idx, dir, config),             \
-		.fifo_threshold = COND_CODE_1(                                     \
-			DT_HAS_COMPAT_STATUS_OKAY(gd_gd32_dma_v1),                     \
-			(DT_INST_DMAS_CELL_BY_NAME(idx, dir, fifo_threshold)),         \
-			(0)),                                                           \
+		.fifo_threshold = COND_CODE_1(DMA_IS_V1(idx, dir),                 \
+			(DT_INST_DMAS_CELL_BY_NAME(idx, dir, fifo_threshold)),     \
+			(0)),                                                       \
 	}
 
 #define USART_DMAS_DECL(idx)                                                   \

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -637,18 +637,39 @@ int spi_gd32_init(const struct device *dev)
 	return 0;
 }
 
+/*
+ * DMA cell mapping based on binding type:
+ * - gd,gd32-dma (3 cells): channel, slot, config
+ * - gd,gd32-dma-v1 (4 cells): channel, slot, config, fifo_threshold
+ * - gd,gd32-dmamux (3 cells): channel, slot, config
+ *
+ * Both gd,gd32-dma-v1 and gd,gd32-dmamux have 'slot' cell.
+ * Only gd,gd32-dma-v1 has 'fifo_threshold' cell.
+ */
+#define DMA_IS_V1(idx, dir) \
+	DT_NODE_HAS_COMPAT(DT_INST_DMAS_CTLR_BY_NAME(idx, dir), gd_gd32_dma_v1)
+
+#define DMA_IS_DMAMUX(idx, dir) \
+	DT_NODE_HAS_COMPAT(DT_INST_DMAS_CTLR_BY_NAME(idx, dir), gd_gd32_dmamux)
+
+/* Get slot value: try v1 first, then dmamux, then standard dma, default to 0 */
+#define DMA_GET_SLOT(idx, dir) \
+	COND_CODE_1(DMA_IS_V1(idx, dir), \
+		(DT_INST_DMAS_CELL_BY_NAME(idx, dir, slot)), \
+		(COND_CODE_1(DMA_IS_DMAMUX(idx, dir), \
+			(DT_INST_DMAS_CELL_BY_NAME(idx, dir, slot)), \
+			(COND_CODE_1(DT_INST_NODE_HAS_PROP(idx, dmas), \
+				(DT_INST_DMAS_CELL_BY_NAME(idx, dir, slot)), (0))))))
+
 #define DMA_INITIALIZER(idx, dir)                                              \
 	{                                                                      \
-		.dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(idx, dir)),     \
+	.dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(idx, dir)),     \
 		.channel = DT_INST_DMAS_CELL_BY_NAME(idx, dir, channel),       \
-		.slot = COND_CODE_1(                                           \
-			DT_HAS_COMPAT_STATUS_OKAY(gd_gd32_dma_v1),             \
-			(DT_INST_DMAS_CELL_BY_NAME(idx, dir, slot)), (0)),     \
+		.slot = DMA_GET_SLOT(idx, dir),                                \
 		.config = DT_INST_DMAS_CELL_BY_NAME(idx, dir, config),         \
-		.fifo_threshold = COND_CODE_1(                                 \
-			DT_HAS_COMPAT_STATUS_OKAY(gd_gd32_dma_v1),             \
+		.fifo_threshold = COND_CODE_1(DMA_IS_V1(idx, dir),             \
 			(DT_INST_DMAS_CELL_BY_NAME(idx, dir, fifo_threshold)), \
-			(0)),						  \
+			(0)),                                                   \
 	}
 
 #define DMAS_DECL(idx)                                                         \

--- a/dts/arm/gd/gd32f50x/gd32f50x.dtsi
+++ b/dts/arm/gd/gd32f50x/gd32f50x.dtsi
@@ -62,7 +62,9 @@
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
-				compatible = "gd,gd32-nv-flash-v3", "soc-nv-flash";
+				compatible = "gd,gd32-nv-flash-v2", "soc-nv-flash";
+				bank0-page-size = <2048>;
+				bank1-page-size = <4096>;
 				write-block-size = <2>;
 				max-erase-time-ms = <8000>;
 			};


### PR DESCRIPTION
- Enhance DMAMUX driver for flexible DMA channel routing
- Adapt SPI driver for GD32F503 series with DMA support
- Improve UART driver compatibility for GD32F503
- Update board configuration for peripheral integration