### PR TITLE
boards: gd: add baseline periph for gd32h7xx

### DIFF
--- a/boards/gd/gd32h759i_eval/gd32h759i_eval-pinctrl.dtsi
+++ b/boards/gd/gd32h759i_eval/gd32h759i_eval-pinctrl.dtsi
@@ -19,6 +19,12 @@
 		};
 	};
 
+	usart2_default: usart2_default {
+		group1 {
+			pinmux = <USART2_TX_PB10>, <USART2_RX_PB11>;
+		};
+	};
+
     adc0_default: adc0_default {
 		group1 {
 			pinmux = <ADC012_IN12_PC2>;
@@ -47,6 +53,13 @@
 	i2c0_default: i2c0_default {
 		group1 {
 			pinmux = <I2C0_SCL_PB6>, <I2C0_SDA_PB7>;
+			drive-open-drain;
+		};
+	};
+
+	i2c1_default: i2c1_default {
+		group1 {
+			pinmux = <I2C1_SCL_PH4>, <I2C1_SDA_PB11>;
 			drive-open-drain;
 		};
 	};
@@ -83,8 +96,8 @@
 
 	spi4_default: spi4_default {
 		group1 {
-			pinmux = <SPI4_SCK_PF7>, <SPI4_MOSI_PF9>,
-				 <SPI4_MISO_PF8>,
+			pinmux = <SPI4_SCK_PH6>, <SPI4_MOSI_PF9>,
+				 <SPI4_MISO_PH7>,
 				 /* Use pinmux to pullup ph8 and ph9. */
 				 <SPI4_IO2_PH8>, <SPI4_IO3_PH9>;
 		};

--- a/boards/gd/gd32h759i_eval/gd32h759i_eval.dts
+++ b/boards/gd/gd32h759i_eval/gd32h759i_eval.dts
@@ -60,6 +60,7 @@
 		pwm-led1 = &pwm_led1;
 		pwm-led2 = &pwm_led2;
 		pwm-led3 = &pwm_led3;
+		eeprom-0 = &eeprom0;
 	};
 };
 
@@ -148,6 +149,13 @@
 	pinctrl-names = "default";
 };
 
+&usart2 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&usart2_default>;
+	pinctrl-names = "default";
+};
+
 &fwdgt {
 	status = "okay";
 };
@@ -164,6 +172,22 @@
 	status = "okay";
 };
 
+&i2c1 {
+	status = "okay";
+	pinctrl-0 = <&i2c1_default>;
+	pinctrl-names = "default";
+	clock-frequency = <100000>;
+	eeprom0: eeprom@50 {
+		compatible = "atmel,at24";
+		reg = <0x50>;
+		status = "okay";
+		size = <256>;
+		pagesize = <8>;
+		address-width = <8>;
+		timeout = <5>;
+	};
+};
+
 &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
@@ -171,13 +195,6 @@
 	cs-gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;
 	dmas = <&dma0 0 48 (2<<16) 0>, <&dma0 1 47 (3<<16) 0>;
 	dma-names = "tx", "rx";
-};
-
-&spi1 {
-	status = "okay";
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-names = "default";
-	cs-gpios = <&gpioa 13 GPIO_ACTIVE_LOW>;
 };
 
 &spi2 {
@@ -198,7 +215,15 @@
 	status = "okay";
 	pinctrl-0 = <&spi4_default>;
 	pinctrl-names = "default";
-	cs-gpios = <&gpiof 6 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpioh 5 GPIO_ACTIVE_LOW>;
+	nor_flash: gd25q16@0 {
+		compatible = "jedec,spi-nor";
+		size = <0x1000000>;
+		reg = <0>;
+		spi-max-frequency = <4000000>;
+		status = "okay";
+		jedec-id = [c8 40 15];
+	};
 };
 
 &spi5 {

--- a/boards/gd/scripts/gd32_peripheral_matrix.yaml
+++ b/boards/gd/scripts/gd32_peripheral_matrix.yaml
@@ -64,6 +64,7 @@ test_groups:
       - gd32f527i_eval
       - gd32f503v_eval
       - gd32e517z_eval
+      - gd32h759i_eval
 
   # 组5: EEPROM测试（只测试有板级配置的）
   eeprom:
@@ -76,6 +77,7 @@ test_groups:
       - gd32f470i_eval
       - gd32f527i_eval
       - gd32f503v_eval
+      - gd32h759i_eval
 
   # 组6: Shell 功能测试
   shell_capable:

--- a/drivers/flash/CMakeLists.txt
+++ b/drivers/flash/CMakeLists.txt
@@ -146,6 +146,7 @@ if(CONFIG_SOC_FLASH_GD32)
   zephyr_library_sources_ifdef(CONFIG_GD32_NV_FLASH_V1 flash_gd32_v1.c)
   zephyr_library_sources_ifdef(CONFIG_GD32_NV_FLASH_V2 flash_gd32_v2.c)
   zephyr_library_sources_ifdef(CONFIG_GD32_NV_FLASH_V3 flash_gd32_v3.c)
+  zephyr_library_sources_ifdef(CONFIG_GD32_NV_FLASH_V4 flash_gd32_v4.c)
 # zephyr-keep-sorted-stop
 endif()
 

--- a/drivers/flash/Kconfig.gd32
+++ b/drivers/flash/Kconfig.gd32
@@ -4,7 +4,7 @@
 config SOC_FLASH_GD32
 	bool "GigaDevice GD32 flash driver"
 	default y
-	depends on (GD32_NV_FLASH_V1 || GD32_NV_FLASH_V2 || GD32_NV_FLASH_V3)
+	depends on (GD32_NV_FLASH_V1 || GD32_NV_FLASH_V2 || GD32_NV_FLASH_V3 || GD32_NV_FLASH_V4)
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_HAS_EXPLICIT_ERASE
@@ -32,3 +32,11 @@ config GD32_NV_FLASH_V3
 	depends on DT_HAS_GD_GD32_NV_FLASH_V3_ENABLED
 	help
 	  Enable the generic backend for GD32 FMC v3 flash driver.
+
+config GD32_NV_FLASH_V4
+	bool
+	default y
+	depends on DT_HAS_GD_GD32_NV_FLASH_V4_ENABLED
+	select USE_GD32_FMC
+	help
+	  Enable the generic backend for GD32 FMC v4 flash driver.

--- a/drivers/flash/flash_gd32_v4.c
+++ b/drivers/flash/flash_gd32_v4.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2022 BrainCo Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "flash_gd32.h"
+
+#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
+#include <gd32_fmc.h>
+
+LOG_MODULE_DECLARE(flash_gd32);
+
+#define GD32_NV_FLASH_V4_NODE      DT_INST(0, gd_gd32_nv_flash_v4)
+#define GD32_NV_FLASH_V4_TIMEOUT   DT_PROP(GD32_NV_FLASH_V4_NODE, max_erase_time_ms)
+#define GD32_NV_FLASH_V4_PAGE_SIZE DT_PROP(GD32_NV_FLASH_V4_NODE, page_size)
+
+/**
+ * @brief GD32 FMC flash memory layout.
+ */
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+
+#if !((PRE_KB(1024) == SOC_NV_FLASH_SIZE) || (PRE_KB(2048) == SOC_NV_FLASH_SIZE) ||                \
+	  (PRE_KB(3840) == SOC_NV_FLASH_SIZE))
+#error "Unknown FMC layout for GD32 flash V4 series."
+#endif
+
+static const struct flash_pages_layout gd32_fmc_v4_layout[] = {
+	{
+	.pages_size = GD32_NV_FLASH_V4_PAGE_SIZE,
+	.pages_count = SOC_NV_FLASH_SIZE / GD32_NV_FLASH_V4_PAGE_SIZE
+	}
+};
+
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */
+
+/* GD32H7xx error flags */
+#define GD32_FMC_V4_WRITE_ERR (FMC_STAT_WPERR | FMC_STAT_PGSERR)
+#define GD32_FMC_V4_ERASE_ERR (FMC_STAT_WPERR | FMC_STAT_PGSERR)
+
+static inline void gd32_fmc_v4_unlock(void)
+{
+	fmc_unlock();
+}
+
+static inline void gd32_fmc_v4_lock(void)
+{
+	fmc_lock();
+}
+
+static int gd32_fmc_v4_wait_idle(void)
+{
+	const int64_t expired_time = k_uptime_get() + GD32_NV_FLASH_V4_TIMEOUT;
+
+	while (FMC_STAT & FMC_STAT_BUSY) {
+		if (k_uptime_get() > expired_time) {
+			return -ETIMEDOUT;
+		}
+	}
+
+	return 0;
+}
+
+bool flash_gd32_valid_range(off_t offset, uint32_t len, bool write)
+{
+	if ((offset > SOC_NV_FLASH_SIZE) || ((offset + len) > SOC_NV_FLASH_SIZE)) {
+		return false;
+	}
+
+	if (write) {
+		/* Check offset and len aligned to write-block-size. */
+		if ((offset % sizeof(flash_prg_t)) || (len % sizeof(flash_prg_t))) {
+			return false;
+		}
+	} else {
+		if ((offset % GD32_NV_FLASH_V4_PAGE_SIZE) || (len % GD32_NV_FLASH_V4_PAGE_SIZE)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+int flash_gd32_write_range(off_t offset, const void *data, size_t len)
+{
+	int ret = 0;
+	flash_prg_t *prg_flash = (flash_prg_t *)((uint8_t *)SOC_NV_FLASH_ADDR + offset);
+	uint32_t *prg_data = (uint32_t *)data;
+
+	gd32_fmc_v4_unlock();
+
+	ret = gd32_fmc_v4_wait_idle();
+	if (ret < 0) {
+		goto expired_out;
+	}
+
+	FMC_CTL |= FMC_CTL_PG;
+	__ISB();
+	__DSB();
+
+	for (size_t i = 0U; i < (len / sizeof(flash_prg_t)); i++) {
+		*prg_flash++ = *prg_data++;
+		__ISB();
+		__DSB();
+	}
+
+	ret = gd32_fmc_v4_wait_idle();
+	if (ret < 0) {
+		goto expired_out;
+	}
+
+	if (FMC_STAT & GD32_FMC_V4_WRITE_ERR) {
+		ret = -EIO;
+		FMC_STAT |= GD32_FMC_V4_WRITE_ERR;
+		LOG_ERR("FMC programming failed");
+	}
+
+expired_out:
+	FMC_CTL &= ~FMC_CTL_PG;
+
+	gd32_fmc_v4_lock();
+
+	return ret;
+}
+
+static int gd32_fmc_v4_sector_erase(uint32_t address)
+{
+	int ret = 0;
+
+	gd32_fmc_v4_unlock();
+
+	ret = gd32_fmc_v4_wait_idle();
+	if (ret < 0) {
+		goto expired_out;
+	}
+
+	FMC_CTL |= FMC_CTL_SER;
+
+	FMC_ADDR = address;
+
+	FMC_CTL |= FMC_CTL_START;
+
+	ret = gd32_fmc_v4_wait_idle();
+	if (ret < 0) {
+		goto expired_out;
+	}
+
+	if (FMC_STAT & GD32_FMC_V4_ERASE_ERR) {
+		ret = -EIO;
+		FMC_STAT |= GD32_FMC_V4_ERASE_ERR;
+		LOG_ERR("FMC sector erase failed");
+	}
+
+expired_out:
+	FMC_CTL &= ~FMC_CTL_SER;
+
+	gd32_fmc_v4_lock();
+
+	return ret;
+}
+
+int flash_gd32_erase_block(off_t offset, size_t size)
+{
+	uint32_t page_addr = SOC_NV_FLASH_ADDR + offset;
+	int ret = 0;
+
+	while (size > 0U) {
+		ret = gd32_fmc_v4_sector_erase(page_addr);
+		if (ret < 0) {
+			gd32_fmc_v4_lock();
+			return ret;
+		}
+		page_addr += GD32_NV_FLASH_V4_PAGE_SIZE;
+		size -= GD32_NV_FLASH_V4_PAGE_SIZE;
+	}
+
+	return 0;
+}
+
+#ifdef CONFIG_FLASH_PAGE_LAYOUT
+void flash_gd32_pages_layout(const struct device *dev, const struct flash_pages_layout **layout,
+			     size_t *layout_size)
+{
+	ARG_UNUSED(dev);
+
+	*layout = gd32_fmc_v4_layout;
+	*layout_size = ARRAY_SIZE(gd32_fmc_v4_layout);
+}
+#endif /* CONFIG_FLASH_PAGE_LAYOUT */

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -32,6 +32,55 @@ LOG_MODULE_REGISTER(spi_gd32);
 
 #define GD32_SPI_PSC_MAX	0x7U
 
+/*
+ * Some GD32 series uses different register layout like ads GD32H7 series.
+ * Define compatibility macros to minimize code changes.
+ */
+#if defined(CONFIG_SOC_SERIES_GD32H7XX)
+
+#define SPI_DATA_TX(spix) SPI_TDATA(spix)
+#define SPI_DATA_RX(spix) SPI_RDATA(spix)
+
+#define SPI_STAT_TX_FLAG SPI_STAT_TP
+#define SPI_STAT_RX_FLAG SPI_STAT_RP
+
+#define SPI_TRANSFER_ONGOING(spix) (!(SPI_STAT(spix) & SPI_STAT_TC))
+
+#define SPI_DMA_ENABLE(spix)  (SPI_CFG0(spix) |= (SPI_CFG0_DMATEN | SPI_CFG0_DMAREN))
+#define SPI_DMA_DISABLE(spix) (SPI_CFG0(spix) &= ~(SPI_CFG0_DMATEN | SPI_CFG0_DMAREN))
+
+#define SPI_INT_DISABLE_ALL(spix)                                                                  \
+	(SPI_INT(spix) &= ~(SPI_INT_RPIE | SPI_INT_TPIE | SPI_INT_RXOREIE | SPI_INT_TXUREIE |      \
+			    SPI_INT_CRCERIE | SPI_INT_CONFEIE))
+
+#define SPI_INT_ENABLE_TRANSCEIVE(spix) (SPI_INT(spix) |= (SPI_INT_RPIE | SPI_INT_TPIE))
+
+#define SPI_INT_ENABLE_ERR(spix)                                                                   \
+	(SPI_INT(spix) |= (SPI_INT_RXOREIE | SPI_INT_TXUREIE | SPI_INT_CRCERIE | SPI_INT_CONFEIE))
+
+#else /* CONFIG_SOC_SERIES_GD32H7XX */
+
+#define SPI_DATA_TX(spix) SPI_DATA(spix)
+#define SPI_DATA_RX(spix) SPI_DATA(spix)
+
+#define SPI_STAT_TX_FLAG SPI_STAT_TBE
+#define SPI_STAT_RX_FLAG SPI_STAT_RBNE
+
+#define SPI_TRANSFER_ONGOING(spix)                                                                 \
+	(!(SPI_STAT(spix) & SPI_STAT_TBE) || (SPI_STAT(spix) & SPI_STAT_TRANS))
+
+#define SPI_DMA_ENABLE(spix)  (SPI_CTL1(spix) |= (SPI_CTL1_DMATEN | SPI_CTL1_DMAREN))
+#define SPI_DMA_DISABLE(spix) (SPI_CTL1(spix) &= ~(SPI_CTL1_DMATEN | SPI_CTL1_DMAREN))
+
+#define SPI_INT_DISABLE_ALL(spix)                                                                  \
+	(SPI_CTL1(spix) &= ~(SPI_CTL1_RBNEIE | SPI_CTL1_TBEIE | SPI_CTL1_ERRIE))
+
+#define SPI_INT_ENABLE_TRANSCEIVE(spix) (SPI_CTL1(spix) |= (SPI_CTL1_RBNEIE | SPI_CTL1_TBEIE))
+
+#define SPI_INT_ENABLE_ERR(spix) (SPI_CTL1(spix) |= SPI_CTL1_ERRIE)
+
+#endif /* CONFIG_SOC_SERIES_GD32H7XX */
+
 #ifdef CONFIG_SPI_GD32_DMA
 
 enum spi_gd32_dma_direction {
@@ -137,6 +186,64 @@ static int spi_gd32_configure(const struct device *dev,
 
 	SPI_CTL0(cfg->reg) &= ~SPI_CTL0_SPIEN;
 
+#if defined(CONFIG_SOC_SERIES_GD32H7XX)
+	uint32_t cfg0 = SPI_CFG0(cfg->reg);
+	uint32_t cfg1 = SPI_CFG1(cfg->reg);
+
+	/* Master mode and full duplex */
+	cfg1 |= SPI_MASTER;
+
+	/* Data size */
+	cfg0 &= ~SPI_CFG0_DZ;
+	if (SPI_WORD_SIZE_GET(config->operation) == 8) {
+		cfg0 |= SPI_DATASIZE_8BIT;
+		cfg0 |= SPI_CFG0_BYTEN; /* Enable byte access */
+	} else if (SPI_WORD_SIZE_GET(config->operation) == 16) {
+		cfg0 |= SPI_DATASIZE_16BIT;
+	} else if (SPI_WORD_SIZE_GET(config->operation) == 32) {
+		cfg0 |= SPI_DATASIZE_32BIT;
+		cfg0 |= SPI_CFG0_WORDEN; /* Enable word access */
+	} else {
+		return -ENOTSUP;
+	}
+
+	/* NSS mode */
+	if (spi_cs_is_gpio(config)) {
+		cfg1 |= SPI_NSS_SOFT;
+	} else {
+		cfg1 |= (SPI_NSS_HARD | SPI_CFG1_NSSDRV);
+	}
+	cfg1 |= SPI_CFG1_NSSDRV;
+
+	/* LSB/MSB */
+	if (config->operation & SPI_TRANSFER_LSB) {
+		cfg1 |= SPI_ENDIAN_LSB;
+	}
+
+	/* Clock polarity and phase */
+	if (config->operation & SPI_MODE_CPOL) {
+		cfg1 |= SPI_CFG1_CKPL;
+	}
+	if (config->operation & SPI_MODE_CPHA) {
+		cfg1 |= SPI_CFG1_CKPH;
+	}
+
+	/* Prescaler */
+	(void)clock_control_get_rate(GD32_CLOCK_CONTROLLER, (clock_control_subsys_t)&cfg->clkid,
+				     &bus_freq);
+	cfg0 &= ~SPI_CFG0_PSC;
+	for (uint8_t i = 0U; i <= GD32_SPI_PSC_MAX; i++) {
+		bus_freq >>= 1;
+		if (bus_freq <= config->frequency) {
+			cfg0 |= CFG0_PSC(i);
+			break;
+		}
+	}
+
+	SPI_CFG0(cfg->reg) = cfg0;
+	SPI_CFG1(cfg->reg) = cfg1;
+	SPI_I2SCTL(cfg->reg) &= ~SPI_I2SCTL_I2SSEL;
+#else  /* CONFIG_SOC_SERIES_GD32H7XX */
 	SPI_CTL0(cfg->reg) |= SPI_MASTER;
 	SPI_CTL0(cfg->reg) &= ~SPI_TRANSMODE_BDTRANSMIT;
 
@@ -185,6 +292,7 @@ static int spi_gd32_configure(const struct device *dev,
 			break;
 		}
 	}
+#endif /* CONFIG_SOC_SERIES_GD32H7XX */
 
 	data->ctx.config = config;
 
@@ -196,9 +304,14 @@ static int spi_gd32_frame_exchange(const struct device *dev)
 	struct spi_gd32_data *data = dev->data;
 	const struct spi_gd32_config *cfg = dev->config;
 	struct spi_context *ctx = &data->ctx;
-	uint16_t tx_frame = 0U, rx_frame = 0U;
 
-	while ((SPI_STAT(cfg->reg) & SPI_STAT_TBE) == 0) {
+#if defined(CONFIG_SOC_SERIES_GD32H7XX)
+	uint32_t tx_frame = 0U, rx_frame = 0U;
+#else
+	uint16_t tx_frame = 0U, rx_frame = 0U;
+#endif
+
+	while ((SPI_STAT(cfg->reg) & SPI_STAT_TX_FLAG) == 0) {
 		/* NOP */
 	}
 
@@ -207,37 +320,68 @@ static int spi_gd32_frame_exchange(const struct device *dev)
 			tx_frame = UNALIGNED_GET((uint8_t *)(data->ctx.tx_buf));
 		}
 		/* For 8 bits mode, spi will forced SPI_DATA[15:8] to 0. */
-		SPI_DATA(cfg->reg) = tx_frame;
+		SPI_DATA_TX(cfg->reg) = tx_frame;
 
 		spi_context_update_tx(ctx, 1, 1);
-	} else {
+	} else if (SPI_WORD_SIZE_GET(ctx->config->operation) == 16) {
 		if (spi_context_tx_buf_on(ctx)) {
-			tx_frame = UNALIGNED_GET((uint8_t *)(data->ctx.tx_buf));
+			tx_frame = UNALIGNED_GET((uint16_t *)(data->ctx.tx_buf));
 		}
-		SPI_DATA(cfg->reg) = tx_frame;
+		SPI_DATA_TX(cfg->reg) = tx_frame;
 
 		spi_context_update_tx(ctx, 2, 1);
 	}
+#if defined(CONFIG_SOC_SERIES_GD32H7XX)
+	else if (SPI_WORD_SIZE_GET(ctx->config->operation) == 32) {
+		if (spi_context_tx_buf_on(ctx)) {
+			tx_frame = UNALIGNED_GET((uint32_t *)(data->ctx.tx_buf));
+		}
+		SPI_DATA_TX(cfg->reg) = tx_frame;
+		spi_context_update_tx(ctx, 4, 1);
+	}
+#endif
+	else {
+		uint32_t frame_size = SPI_WORD_SIZE_GET(ctx->config->operation);
 
-	while ((SPI_STAT(cfg->reg) & SPI_STAT_RBNE) == 0) {
+		LOG_ERR("Unsupported frame size %d bits", frame_size);
+		return -ENOTSUP;
+	}
+
+	while ((SPI_STAT(cfg->reg) & SPI_STAT_RX_FLAG) == 0) {
 		/* NOP */
 	}
 
 	if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 8) {
 		/* For 8 bits mode, spi will forced SPI_DATA[15:8] to 0. */
-		rx_frame = SPI_DATA(cfg->reg);
+		rx_frame = SPI_DATA_RX(cfg->reg);
 		if (spi_context_rx_buf_on(ctx)) {
 			UNALIGNED_PUT(rx_frame, (uint8_t *)data->ctx.rx_buf);
 		}
 
 		spi_context_update_rx(ctx, 1, 1);
-	} else {
-		rx_frame = SPI_DATA(cfg->reg);
+	} else if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 16) {
+		rx_frame = SPI_DATA_RX(cfg->reg);
 		if (spi_context_rx_buf_on(ctx)) {
 			UNALIGNED_PUT(rx_frame, (uint16_t *)data->ctx.rx_buf);
 		}
 
 		spi_context_update_rx(ctx, 2, 1);
+	}
+#if defined(CONFIG_SOC_SERIES_GD32H7XX)
+	else if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 32) {
+		rx_frame = SPI_DATA_RX(cfg->reg);
+		if (spi_context_rx_buf_on(ctx)) {
+			UNALIGNED_PUT(rx_frame, (uint32_t *)data->ctx.rx_buf);
+		}
+
+		spi_context_update_rx(ctx, 4, 1);
+	}
+#endif
+	else {
+		uint32_t frame_size = SPI_WORD_SIZE_GET(data->ctx.config->operation);
+
+		LOG_ERR("Unsupported frame size %d bits", frame_size);
+		return -ENOTSUP;
 	}
 
 	return spi_gd32_get_err(cfg);
@@ -274,15 +418,27 @@ static uint32_t spi_gd32_dma_setup(const struct device *dev, const uint32_t dir)
 	if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 8) {
 		dma_cfg->source_data_size = 1;
 		dma_cfg->dest_data_size = 1;
-	} else {
+	} else if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 16) {
 		dma_cfg->source_data_size = 2;
 		dma_cfg->dest_data_size = 2;
+	}
+#if defined(CONFIG_SOC_SERIES_GD32H7XX)
+	else if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 32) {
+		dma_cfg->source_data_size = 4;
+		dma_cfg->dest_data_size = 4;
+	}
+#endif
+	else {
+		uint32_t frame_size = SPI_WORD_SIZE_GET(data->ctx.config->operation);
+
+		LOG_ERR("Unsupported frame size %d bits", frame_size);
+		return -ENOTSUP;
 	}
 
 	block_cfg->block_size = spi_context_max_continuous_chunk(&data->ctx);
 
 	if (dir == TX) {
-		block_cfg->dest_address = (uint32_t)&SPI_DATA(cfg->reg);
+		block_cfg->dest_address = (uint32_t)&SPI_DATA_TX(cfg->reg);
 		block_cfg->dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 		if (spi_context_tx_buf_on(&data->ctx)) {
 			block_cfg->source_address = (uint32_t)data->ctx.tx_buf;
@@ -294,7 +450,7 @@ static uint32_t spi_gd32_dma_setup(const struct device *dev, const uint32_t dir)
 	}
 
 	if (dir == RX) {
-		block_cfg->source_address = (uint32_t)&SPI_DATA(cfg->reg);
+		block_cfg->source_address = (uint32_t)&SPI_DATA_RX(cfg->reg);
 		block_cfg->source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
 
 		if (spi_context_rx_buf_on(&data->ctx)) {
@@ -311,6 +467,10 @@ static uint32_t spi_gd32_dma_setup(const struct device *dev, const uint32_t dir)
 		LOG_ERR("dma_config %p failed %d\n", dma->dev, ret);
 		return ret;
 	}
+
+#ifdef CONFIG_DCACHE
+	SCB_CleanInvalidateDCache();
+#endif
 
 	ret = dma_start(dma->dev, dma->channel);
 	if (ret < 0) {
@@ -339,7 +499,7 @@ static int spi_gd32_start_dma_transceive(const struct device *dev)
 		}
 	}
 
-	SPI_CTL1(cfg->reg) |= (SPI_CTL1_DMATEN | SPI_CTL1_DMAREN);
+	SPI_DMA_ENABLE(cfg->reg);
 
 on_error:
 	if (ret < 0) {
@@ -375,6 +535,10 @@ static int spi_gd32_transceive_impl(const struct device *dev,
 
 	spi_context_cs_control(&data->ctx, true);
 
+#if defined(CONFIG_SOC_SERIES_GD32H7XX)
+	SPI_CTL0(cfg->reg) |= (uint32_t)SPI_CTL0_MSTART;
+#endif
+
 #ifdef CONFIG_SPI_GD32_INTERRUPT
 #ifdef CONFIG_SPI_GD32_DMA
 	if (spi_gd32_dma_enabled(dev)) {
@@ -389,10 +553,13 @@ static int spi_gd32_transceive_impl(const struct device *dev,
 	} else
 #endif
 	{
-		SPI_STAT(cfg->reg) &=
-			~(SPI_STAT_RBNE | SPI_STAT_TBE | SPI_GD32_ERR_MASK);
-		SPI_CTL1(cfg->reg) |=
-			(SPI_CTL1_RBNEIE | SPI_CTL1_TBEIE | SPI_CTL1_ERRIE);
+#if defined(CONFIG_SOC_SERIES_GD32H7XX)
+		SPI_STATC(cfg->reg) &= ~(SPI_STAT_RP | SPI_STAT_TP | SPI_GD32_ERR_MASK);
+		SPI_INT(cfg->reg) |= (SPI_INT_RPIE | SPI_INT_TPIE | SPI_INT_FEIE);
+#else
+		SPI_STAT(cfg->reg) &= ~(SPI_STAT_RBNE | SPI_STAT_TBE | SPI_GD32_ERR_MASK);
+		SPI_CTL1(cfg->reg) |= (SPI_CTL1_RBNEIE | SPI_CTL1_TBEIE | SPI_CTL1_ERRIE);
+#endif
 	}
 	ret = spi_context_wait_for_completion(&data->ctx);
 #else
@@ -408,20 +575,21 @@ static int spi_gd32_transceive_impl(const struct device *dev,
 #endif
 #endif
 
-	while (!(SPI_STAT(cfg->reg) & SPI_STAT_TBE) ||
-		(SPI_STAT(cfg->reg) & SPI_STAT_TRANS)) {
+	while (SPI_TRANSFER_ONGOING(cfg->reg)) {
 		/* Wait until last frame transfer complete. */
 	}
 
 #ifdef CONFIG_SPI_GD32_DMA
 dma_error:
-	SPI_CTL1(cfg->reg) &=
-		~(SPI_CTL1_DMATEN | SPI_CTL1_DMAREN);
+	SPI_DMA_DISABLE(cfg->reg);
 #endif
 	spi_context_cs_control(&data->ctx, false);
 
-	SPI_CTL0(cfg->reg) &=
-		~(SPI_CTL0_SPIEN);
+	SPI_CTL0(cfg->reg) &= ~(SPI_CTL0_SPIEN);
+
+#ifdef CONFIG_DCACHE
+	SCB_CleanInvalidateDCache();
+#endif
 
 error:
 	spi_context_release(&data->ctx, ret);
@@ -456,8 +624,11 @@ static void spi_gd32_complete(const struct device *dev, int status)
 	struct spi_gd32_data *data = dev->data;
 	const struct spi_gd32_config *cfg = dev->config;
 
-	SPI_CTL1(cfg->reg) &=
-		~(SPI_CTL1_RBNEIE | SPI_CTL1_TBEIE | SPI_CTL1_ERRIE);
+#if defined(CONFIG_SOC_SERIES_GD32H7XX)
+	SPI_INT(cfg->reg) &= ~(SPI_INT_RPIE | SPI_INT_TPIE | SPI_INT_FEIE);
+#else
+	SPI_CTL1(cfg->reg) &= ~(SPI_CTL1_RBNEIE | SPI_CTL1_TBEIE | SPI_CTL1_ERRIE);
+#endif
 
 #ifdef CONFIG_SPI_GD32_DMA
 	for (size_t i = 0; i < spi_gd32_dma_enabled_num(dev); i++) {
@@ -534,9 +705,22 @@ static void spi_gd32_dma_callback(const struct device *dma_dev, void *arg,
 		if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 8) {
 			spi_context_update_tx(&data->ctx, 1, chunk_len);
 			spi_context_update_rx(&data->ctx, 1, chunk_len);
-		} else {
+		} else if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 16) {
 			spi_context_update_tx(&data->ctx, 2, chunk_len);
 			spi_context_update_rx(&data->ctx, 2, chunk_len);
+		}
+#if defined(CONFIG_SOC_SERIES_GD32H7XX)
+		else if (SPI_WORD_SIZE_GET(data->ctx.config->operation) == 32) {
+			spi_context_update_tx(&data->ctx, 4, chunk_len);
+			spi_context_update_rx(&data->ctx, 4, chunk_len);
+		}
+#endif
+		else {
+			uint32_t frame_size = SPI_WORD_SIZE_GET(data->ctx.config->operation);
+
+			LOG_ERR("Unsupported frame size %d bits", frame_size);
+			spi_gd32_complete(dev, -ENOTSUP);
+			return;
 		}
 
 		if (spi_gd32_transfer_ongoing(data)) {

--- a/dts/arm/gd/gd32h7xx/gd32h7xx.dtsi
+++ b/dts/arm/gd/gd32h7xx/gd32h7xx.dtsi
@@ -57,7 +57,7 @@
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
-				compatible = "gd,gd32-nv-flash-v1", "soc-nv-flash";
+				compatible = "gd,gd32-nv-flash-v4", "soc-nv-flash";
 				write-block-size = <2>;
 				max-erase-time-ms = <8000>;
 				page-size = <DT_SIZE_K(4)>;
@@ -90,6 +90,60 @@
 			status = "disabled";
 		};
 
+		usart2: usart@40004800 {
+			compatible = "gd,gd32-usart";
+			reg = <0x40004800 0x400>;
+			interrupts = <39 1>;
+			clocks = <&cctl GD32_CLOCK_USART2>;
+			resets = <&rctl GD32_RESET_USART2>;
+			status = "disabled";
+		};
+
+		uart3: usart@40004c00 {
+			compatible = "gd,gd32-usart";
+			reg = <0x40004c00 0x400>;
+			interrupts = <52 0>;
+			clocks = <&cctl GD32_CLOCK_UART3>;
+			resets = <&rctl GD32_RESET_UART3>;
+			status = "disabled";
+		};
+
+		uart4: usart@40005000 {
+			compatible = "gd,gd32-usart";
+			reg = <0x40005000 0x400>;
+			interrupts = <53 0>;
+			clocks = <&cctl GD32_CLOCK_UART4>;
+			resets = <&rctl GD32_RESET_UART4>;
+			status = "disabled";
+		};
+
+		usart5: usart@40011400 {
+			compatible = "gd,gd32-usart";
+			reg = <0x40011400 0x400>;
+			interrupts = <71 0>;
+			clocks = <&cctl GD32_CLOCK_USART5>;
+			resets = <&rctl GD32_RESET_USART5>;
+			status = "disabled";
+		};
+
+		uart6: usart@40007800 {
+			compatible = "gd,gd32-usart";
+			reg = <0x40007800 0x400>;
+			interrupts = <82 0>;
+			clocks = <&cctl GD32_CLOCK_UART6>;
+			resets = <&rctl GD32_RESET_UART6>;
+			status = "disabled";
+		};
+
+		uart7: usart@40007c00 {
+			compatible = "gd,gd32-usart";
+			reg = <0x40007c00 0x400>;
+			interrupts = <83 0>;
+			clocks = <&cctl GD32_CLOCK_UART7>;
+			resets = <&rctl GD32_RESET_UART7>;
+			status = "disabled";
+		};
+
 		adc0: adc@40012400 {
 			compatible = "gd,gd32-adc-trigsel", "gd,gd32-adc";
 			reg = <0x40012400 0x100>;
@@ -100,6 +154,58 @@
 			status = "disabled";
 			#io-channel-cells = <1>;
 			trigger-select = <0x0>;
+		};
+
+		i2c0: i2c@40005400 {
+			compatible = "gd,gd32-i2c-v2";
+			reg = <0x40005400 0x400>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <31 0>, <32 0>;
+			interrupt-names = "event", "error";
+			clocks = <&cctl GD32_CLOCK_I2C0>;
+			resets = <&rctl GD32_RESET_I2C0>;
+			status = "disabled";
+		};
+
+		i2c1: i2c@40005800 {
+			compatible = "gd,gd32-i2c-v2";
+			reg = <0x40005800 0x400>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <33 0>, <34 0>;
+			interrupt-names = "event", "error";
+			clocks = <&cctl GD32_CLOCK_I2C1>;
+			resets = <&rctl GD32_RESET_I2C1>;
+			status = "disabled";
+		};
+
+		i2c2: i2c@4000c000 {
+			compatible = "gd,gd32-i2c-v2";
+			reg = <0x4000c000 0x400>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <72 0>, <73 0>;
+			interrupt-names = "event", "error";
+			clocks = <&cctl GD32_CLOCK_I2C1>;
+			resets = <&rctl GD32_RESET_I2C1>;
+			status = "disabled";
+		};
+
+		i2c3: i2c@40005c00 {
+			compatible = "gd,gd32-i2c-v2";
+			reg = <0x40005c00 0x400>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clock-frequency = <I2C_BITRATE_STANDARD>;
+			interrupts = <95 0>, <96 0>;
+			interrupt-names = "event", "error";
+			clocks = <&cctl GD32_CLOCK_I2C3>;
+			resets = <&rctl GD32_RESET_I2C3>;
+			status = "disabled";
 		};
 
 		spi0: spi@40013000 {

--- a/dts/bindings/flash_controller/gd,gd32-flash-controller.yaml
+++ b/dts/bindings/flash_controller/gd,gd32-flash-controller.yaml
@@ -14,6 +14,9 @@ description: |
   GD32 FMC v3: its flash memory has 2 banks, use sector size as the minimum operating
   unit, the sector size is not equal.
 
+  GD32 FMC v4: its flash memory has 1 bank, page size is equal in the bank,
+  flash size is smaller than 3840KB, with flash RTDEC. Such as GD32H7xx.
+
 compatible: "gd,gd32-flash-controller"
 
 include: flash-controller.yaml

--- a/dts/bindings/mtd/gd,gd32-nv-flash-v4.yaml
+++ b/dts/bindings/mtd/gd,gd32-nv-flash-v4.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Flash memory binding of GD32 FMC v4.
+
+  GD32 series use this type flash memory:
+    - GD32H7xx
+
+include: soc-nv-flash.yaml
+
+compatible: gd,gd32-nv-flash-v4
+
+properties:
+  max-erase-time-ms:
+    type: int
+    required: true
+    description: Max erase time(millisecond) of a flash page
+
+  page-size:
+    type: int
+    required: true
+    description: Flash memory page size


### PR DESCRIPTION
Add I2C, SPI peripheral support for the gd32h7xx series, board, device tree, Kconfig files.