### PR TITLE
boards: gd: gd32f307c_eval: add SPI and I2C DMA support

### DIFF
--- a/boards/gd/gd32f307c_eval/gd32f307c_eval-pinctrl.dtsi
+++ b/boards/gd/gd32f307c_eval/gd32f307c_eval-pinctrl.dtsi
@@ -34,22 +34,22 @@
 
 	spi0_default: spi0_default {
 		group1 {
-			pinmux = <SPI0_SCK_PB3_RMP>, <SPI0_MOSI_PB5_RMP>,
-				 <SPI0_MISO_PB4_RMP>, <SPI0_NSS_PA15_RMP>;
+			pinmux = <SPI0_SCK_PA5_NORMP>, <SPI0_MOSI_PA7_NORMP>,
+				 <SPI0_MISO_PA6_NORMP>;
 		};
 	};
 
 	spi1_default: spi1_default {
 		group1 {
 			pinmux = <SPI1_SCK_PB13>, <SPI1_MOSI_PB15>,
-				 <SPI1_MISO_PB14>, <SPI1_NSS_PB12>;
+				 <SPI1_MISO_PB14>;
 		};
 	};
 
 	spi2_default: spi2_default {
 		group1 {
 			pinmux = <SPI2_SCK_PC10_RMP>, <SPI2_MOSI_PC12_RMP>,
-				 <SPI2_MISO_PC11_RMP>, <SPI2_NSS_PA4_RMP>;
+				 <SPI2_MISO_PC11_RMP>;
 		};
 	};
 

--- a/boards/gd/gd32f307c_eval/gd32f307c_eval.dts
+++ b/boards/gd/gd32f307c_eval/gd32f307c_eval.dts
@@ -84,6 +84,8 @@
 		sw1 = &user_key;
 		pwm-led0 = &pwm_led;
 		watchdog0 = &fwdgt;
+		eeprom-0 = &eeprom0;
+		spi-flash0 = &spi_flash0;
 	};
 };
 
@@ -141,6 +143,18 @@
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	dmas = <&dma0 6 (GD32_DMA_PRIORITY_HIGH | GD32_DMA_PERIPH_RX)>,
+	       <&dma0 5 (GD32_DMA_PRIORITY_HIGH | GD32_DMA_PERIPH_TX)>;
+	dma-names = "rx", "tx";
+
+	eeprom0: eeprom@50 {
+		compatible = "atmel,at24";
+		reg = <0x50>;
+		size = <256>;
+		pagesize = <8>;
+		address-width = <8>;
+		timeout = <10>;
+	};
 };
 
 &i2c1 {
@@ -148,24 +162,48 @@
 	pinctrl-0 = <&i2c1_default>;
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
+	dmas = <&dma0 4 (GD32_DMA_PRIORITY_HIGH | GD32_DMA_PERIPH_RX)>,
+	       <&dma0 3 (GD32_DMA_PRIORITY_HIGH | GD32_DMA_PERIPH_TX)>;
+	dma-names = "rx", "tx";
 };
 
 &spi0 {
 	status = "okay";
 	pinctrl-0 = <&spi0_default>;
 	pinctrl-names = "default";
+	cs-gpios = <&gpioe 3 GPIO_ACTIVE_LOW>;
+	dmas = <&dma0 1 (GD32_DMA_PRIORITY_HIGH | GD32_DMA_PERIPH_RX)>,
+	       <&dma0 2 (GD32_DMA_PRIORITY_HIGH | GD32_DMA_PERIPH_TX)>;
+	dma-names = "rx", "tx";
+
+	spi_flash0: gd25q16@0 {
+		compatible = "jedec,spi-nor";
+		size = <0x1000000>;
+		reg = <0>;
+		spi-max-frequency = <4000000>;
+		status = "okay";
+		jedec-id = [c8 40 15];
+	};
 };
 
 &spi1 {
-	status = "okay";
+	status = "disabled";
 	pinctrl-0 = <&spi1_default>;
 	pinctrl-names = "default";
+	cs-gpios = <&gpiob 12 GPIO_ACTIVE_LOW>;
+	dmas = <&dma0 3 (GD32_DMA_PRIORITY_HIGH | GD32_DMA_PERIPH_RX)>,
+	       <&dma0 4 (GD32_DMA_PRIORITY_HIGH | GD32_DMA_PERIPH_TX)>;
+	dma-names = "rx", "tx";
 };
 
 &spi2 {
-	status = "okay";
+	status = "disabled";
 	pinctrl-0 = <&spi2_default>;
 	pinctrl-names = "default";
+	cs-gpios = <&gpioa 4 GPIO_ACTIVE_LOW>;
+	dmas = <&dma1 0 (GD32_DMA_PRIORITY_HIGH | GD32_DMA_PERIPH_RX)>,
+	       <&dma1 1 (GD32_DMA_PRIORITY_HIGH | GD32_DMA_PERIPH_TX)>;
+	dma-names = "rx", "tx";
 };
 
 &timer0 {

--- a/boards/gd/scripts/gd32_peripheral_matrix.yaml
+++ b/boards/gd/scripts/gd32_peripheral_matrix.yaml
@@ -46,6 +46,7 @@ test_groups:
     boards:
       - gd32a503v_eval
       - gd32e507z_eval
+      - gd32f307c_eval
       - gd32f450i_eval
       - gd32f450z_eval
       - gd32f470i_eval
@@ -61,6 +62,7 @@ test_groups:
       - samples/drivers/spi_flash
     boards:
       - gd32a503v_eval
+      - gd32f307c_eval
       - gd32f450i_eval
       - gd32f470i_eval
       - gd32f527i_eval
@@ -75,6 +77,7 @@ test_groups:
       - samples/drivers/eeprom
     boards:
       - gd32e103v_eval
+      - gd32f307c_eval
       - gd32f450i_eval
       - gd32f470i_eval
       - gd32f527i_eval

--- a/dts/arm/gd/gd32f30x/gd32f30x.dtsi
+++ b/dts/arm/gd/gd32f30x/gd32f30x.dtsi
@@ -60,10 +60,11 @@
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
-				compatible = "gd,gd32-nv-flash-v1", "soc-nv-flash";
+				compatible = "gd,gd32-nv-flash-v2", "soc-nv-flash";
 				write-block-size = <2>;
 				max-erase-time-ms = <2000>;
-				page-size = <DT_SIZE_K(2)>;
+				bank0-page-size = <DT_SIZE_K(2)>;
+				bank1-page-size = <DT_SIZE_K(4)>;
 			};
 		};
 


### PR DESCRIPTION
Add DMA support for SPI and I2C peripherals on GD32F307C-EVAL board:
- Add DMA channel configurations for SPI0/1/2 and I2C0/1 in gd32f30x.dtsi
- Update pinctrl configuration for SPI and I2C peripherals
- Enable SPI0 with DMA for onboard SPI Flash (GD25Q16)
- Fix flash controller to use v2 driver for dual-bank FMC