### PR TITLE
gd32h759i_start : update and enhance driver support

### DIFF
--- a/boards/gd/gd32h759i_start/Kconfig
+++ b/boards/gd/gd32h759i_start/Kconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_INIT_PRIORITY
+	int "Board initialization priority"
+	default 50
+	help
+	  Board initialization priority.

--- a/boards/gd/gd32h759i_start/Kconfig.defconfig
+++ b/boards/gd/gd32h759i_start/Kconfig.defconfig
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_GD32H759I_START
+
+config BOARD
+	default "gd32h759i_start"
+
+endif # BOARD_GD32H759I_START

--- a/boards/gd/gd32h759i_start/Kconfig.gd32h759i_start
+++ b/boards/gd/gd32h759i_start/Kconfig.gd32h759i_start
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_GD32H759I_START
+	select SOC_GD32H759

--- a/boards/gd/gd32h759i_start/board.cmake
+++ b/boards/gd/gd32h759i_start/board.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+
+board_runner_args(pyocd "--target=GD32H759IM" "--tool-opt=--pack=${ZEPHYR_HAL_GIGADEVICE_MODULE_DIR}/${CONFIG_SOC_SERIES}/support/GigaDevice.GD32H7xx_DFP.1.0.0.pack")
+
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/gd/gd32h759i_start/board.yml
+++ b/boards/gd/gd32h759i_start/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: gd32h759i_start
+  full_name: GD32H759I-START
+  vendor: gd
+  socs:
+    - name: gd32h759

--- a/boards/gd/gd32h759i_start/doc/index.rst
+++ b/boards/gd/gd32h759i_start/doc/index.rst
@@ -1,0 +1,155 @@
+.. zephyr:board:: gd32h759i_start
+
+GigaDevice GD32H759I-START
+##########################
+
+Overview
+********
+
+The GD32H759I-START board is a hardware platform that enables prototyping
+on GD32H759I Cortex-M7 Stretch Performance MCU.
+
+The GD32H759IMT6 features a single-core ARM Cortex-M7 MCU which can run up
+to 600 MHz with 3072kiB of Flash, 1024kiB of SRAM and 176 PINs.
+
+Hardware
+********
+
+- GD32H759IMT6 MCU
+- 4 x User LEDs
+- 1 x User Push button
+- 1 x USART (CH340E USB-to-Serial at Mini-USB connector CN1)
+- GD-Link on board programmer
+- J-Link/JTAG connector
+
+For more information about the GD32H759IM SoC and GD32H759I-START board:
+
+- `GigaDevice Cortex-M7 Stretch Performance SoC Website`_
+- `GD32H759 Datasheet`_
+- `GD32H7xx User Manual`_
+
+Supported Features
+==================
+
+The board configuration supports the following hardware features:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Peripheral
+     - Kconfig option
+     - Devicetree compatible
+   * - GPIO
+     - :kconfig:option:`CONFIG_GPIO`
+     - :dtcompatible:`gd,gd32-gpio`
+   * - USART
+     - :kconfig:option:`CONFIG_SERIAL`
+     - :dtcompatible:`gd,gd32-usart`
+
+Serial Port
+===========
+
+The GD32H759I-START board has one serial communication port connected via
+USB-to-Serial converter (CH340E). The default port is USART0 with TX
+connected at PF4 and RX at PF5. Connect to Mini-USB connector CN1 for
+serial console access.
+
+Connections and IOs
+===================
+
+LED Connections
+---------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - GPIO Pin
+     - Active Level
+   * - LED1
+     - PC9
+     - Low
+   * - LED2
+     - PC10
+     - Low
+   * - LED3
+     - PC11
+     - Low
+   * - LED4
+     - PC12
+     - Low
+
+Button Connections
+------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Name
+     - GPIO Pin
+     - Description
+   * - K2
+     - PD15
+     - User button (active low with pull-up)
+
+Programming and Debugging
+*************************
+
+Before programming your board make sure to configure boot and serial jumpers
+as follows:
+
+- JP2 BOOT: Connect to GND for normal boot from Flash
+
+Using GD-Link
+=============
+
+The GD32H759I-START includes an integrated GD-Link adapter which
+provides debugging and flash programming capabilities.
+
+#. Build the Zephyr kernel and the :zephyr:code-sample:`blinky` sample application:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/basic/blinky
+      :board: gd32h759i_start
+      :goals: build
+      :compact:
+
+#. Connect the board to your host computer using the USB cable connected to
+   the GD-Link Mini-USB connector.
+
+#. Run your favorite terminal program to listen for output. Under Linux the
+   terminal should be :code:`/dev/ttyUSB0`. For example:
+
+   .. code-block:: console
+
+      $ minicom -D /dev/ttyUSB0 -o
+
+   The -o option tells minicom not to send the modem initialization string.
+   Connection should be configured as follows:
+
+   - Speed: 115200
+   - Data: 8 bits
+   - Parity: None
+   - Stop bits: 1
+
+#. Flash the image:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/basic/blinky
+      :board: gd32h759i_start
+      :goals: flash
+      :compact:
+
+   You should see LED1 (PC9) blinking.
+
+Debugging
+=========
+
+You can debug an application with pyocd or jlink debugger.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: gd32h759i_start
+   :maybe-hierarchical: west debug
+   :goals: debug
+   :compact:

--- a/boards/gd/gd32h759i_start/gd32h759i_start-pinctrl.dtsi
+++ b/boards/gd/gd32h759i_start/gd32h759i_start-pinctrl.dtsi
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 GigaDevice Semiconductor Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pinctrl/gd32h759i(g-i-m)xx-pinctrl.h>
+
+&pinctrl {
+	usart0_default: usart0_default {
+		group1 {
+			pinmux = <USART0_TX_PF4>, <USART0_RX_PF5>;
+		};
+	};
+};

--- a/boards/gd/gd32h759i_start/gd32h759i_start.dts
+++ b/boards/gd/gd32h759i_start/gd32h759i_start.dts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 GigaDevice Semiconductor Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <gd/gd32h7xx/gd32h759im.dtsi>
+#include "gd32h759i_start-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "GigaDevice GD32H759I-START";
+	compatible = "gd,gd32h759i-start";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,dtcm = &dtcm;
+		zephyr,flash = &flash0;
+		zephyr,console = &usart0;
+		zephyr,shell-uart = &usart0;
+		zephyr,flash-controller = &fmc;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led1: led1 {
+			gpios = <&gpioc 9 GPIO_ACTIVE_LOW>;
+			label = "LED1";
+		};
+		led2: led2 {
+			gpios = <&gpioc 10 GPIO_ACTIVE_LOW>;
+			label = "LED2";
+		};
+		led3: led3 {
+			gpios = <&gpioc 11 GPIO_ACTIVE_LOW>;
+			label = "LED3";
+		};
+		led4: led4 {
+			gpios = <&gpioc 12 GPIO_ACTIVE_LOW>;
+			label = "LED4";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		user_key: user_key {
+			gpios = <&gpiod 15 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "USER_KEY";
+			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+
+	aliases {
+		led0 = &led1;
+		led1 = &led2;
+		led2 = &led3;
+		led3 = &led4;
+		sw0 = &user_key;
+		watchdog0 = &fwdgt;
+	};
+};
+
+&gpioc {
+	status = "okay";
+};
+
+&gpiod {
+	status = "okay";
+};
+
+&gpiof {
+	status = "okay";
+};
+
+&usart0 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+};
+
+&backup_sram {
+	status = "okay";
+};

--- a/boards/gd/gd32h759i_start/gd32h759i_start.yaml
+++ b/boards/gd/gd32h759i_start/gd32h759i_start.yaml
@@ -1,0 +1,15 @@
+identifier: gd32h759i_start
+name: GD32H759I-START
+type: mcu
+arch: arm
+ram: 1024
+flash: 3072
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+supported:
+  - gpio
+  - uart
+  - watchdog
+vendor: gd

--- a/boards/gd/gd32h759i_start/gd32h759i_start_defconfig
+++ b/boards/gd/gd32h759i_start/gd32h759i_start_defconfig
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ARM_MPU=y
+CONFIG_HW_STACK_PROTECTION=y
+
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_SERIAL=y
+
+CONFIG_GPIO=y
+
+CONFIG_CACHE_MANAGEMENT=y

--- a/boards/gd/scripts/gd32_peripheral_matrix.yaml
+++ b/boards/gd/scripts/gd32_peripheral_matrix.yaml
@@ -40,6 +40,7 @@ test_groups:
       - gd32h75ey_eval
       - gd32g553q_eval
       - gd32c113v_eval
+      - gd32h759i_start
 
   # 组3: UART async_api 驱动测试
   uart_async_api:
@@ -119,3 +120,4 @@ test_groups:
       - gd32h75ey_eval
       - gd32g553q_eval
       - gd32c113v_eval
+      - gd32h759i_start


### PR DESCRIPTION
Update system support:

Driver updates:
-  Add mini_system support for H759i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the GD32H759I-START board: MCU, RAM, and flash specs; GPIO, UART console, and watchdog enabled
  * Four user LEDs and one user button exposed; J-Link and pyOCD debugging/flash support
  * Configurable board initialization priority available

* **Documentation**
  * Complete board documentation, pinout, flashing and debugging instructions included

* **Tests**
  * Board added to UART echo and shell-capable test groups
<!-- end of auto-generated comment: release notes by coderabbit.ai -->