### PR TITLE
boards: gd: add GD32C231K-START board

### DIFF
--- a/boards/gd/gd32c231k_start/Kconfig.gd32c231k_start
+++ b/boards/gd/gd32c231k_start/Kconfig.gd32c231k_start
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_GD32C231K_START
+	select SOC_GD32C231

--- a/boards/gd/gd32c231k_start/board.cmake
+++ b/boards/gd/gd32c231k_start/board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(jlink "--device=GD32C231K8" "--speed=4000")
+
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/gd/gd32c231k_start/board.yml
+++ b/boards/gd/gd32c231k_start/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: gd32c231k_start
+  full_name: GD32C231K-START
+  vendor: gd
+  socs:
+    - name: gd32c231

--- a/boards/gd/gd32c231k_start/doc/index.rst
+++ b/boards/gd/gd32c231k_start/doc/index.rst
@@ -1,0 +1,65 @@
+.. _gd32c231k_start:
+
+GD32C231K-START
+###############
+
+Overview
+********
+
+The GD32C231K-START is a minimal system development board for the
+GigaDevice GD32C231K microcontroller series based on ARM Cortex-M23 core.
+
+The GD32C231K8 features:
+
+- ARM Cortex-M23 processor at 48MHz maximum
+- 64KB Flash memory
+- 12KB SRAM
+- Low power operation
+- Multiple communication interfaces: UART, SPI, I2C
+- GPIO ports
+- Timer modules
+- ADC and comparator
+
+Hardware
+********
+
+- MCU: GD32C231K8T6 (LQFP32)
+- Crystal: 8MHz external crystal for HXTAL
+- LED: User LED connected to PA8
+- Debug: SWD interface
+
+Connections and IOs
+===================
+
+LED
+---
+
+- LED0 (User) = PA8
+
+UART
+----
+
+- USART0_TX = PA9
+- USART0_RX = PA10
+
+Programming and Debugging
+*************************
+
+Flashing
+========
+
+The GD32C231K-START board can be flashed using OpenOCD with a CMSIS-DAP
+compatible debug adapter, or using J-Link.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: gd32c231k_start
+   :goals: flash
+
+Debugging
+=========
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: gd32c231k_start
+   :goals: debug

--- a/boards/gd/gd32c231k_start/gd32c231k_start-pinctrl.dtsi
+++ b/boards/gd/gd32c231k_start/gd32c231k_start-pinctrl.dtsi
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 GigaDevice Semiconductor Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pinctrl/gd32c231k(6-8)xx-pinctrl.h>
+
+&pinctrl {
+	usart0_default: usart0_default {
+		group1 {
+			pinmux = <USART0_TX_PA9>, <USART0_RX_PA10>;
+		};
+	};
+};

--- a/boards/gd/gd32c231k_start/gd32c231k_start.dts
+++ b/boards/gd/gd32c231k_start/gd32c231k_start.dts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 GigaDevice Semiconductor Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <gd/gd32c2x1/gd32c231k8.dtsi>
+#include "gd32c231k_start-pinctrl.dtsi"
+
+/ {
+	model = "GigaDevice GD32C231K-START";
+	compatible = "gd,gd32c231k-start";
+
+	chosen {
+		zephyr,flash = &flash0;
+		zephyr,sram = &sram0;
+		zephyr,console = &usart0;
+		zephyr,shell-uart = &usart0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led0 {
+			gpios = <&gpiob 8 GPIO_ACTIVE_HIGH>;
+			label = "LED1";
+		};
+	};
+
+	aliases {
+		led0 = &led0;
+	};
+};
+
+&gpioa {
+	status = "okay";
+};
+
+&gpiob {
+	status = "okay";
+};
+
+&usart0 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+};

--- a/boards/gd/gd32c231k_start/gd32c231k_start.yaml
+++ b/boards/gd/gd32c231k_start/gd32c231k_start.yaml
@@ -1,5 +1,5 @@
-identifier: gd32c231c_eval
-name: GD32C231C-EVAL
+identifier: gd32c231k_start
+name: GD32C231K-START
 type: mcu
 arch: arm
 toolchain:

--- a/boards/gd/gd32c231k_start/gd32c231k_start_defconfig
+++ b/boards/gd/gd32c231k_start/gd32c231k_start_defconfig
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_CONSOLE=y
+CONFIG_SERIAL=y
+CONFIG_UART_CONSOLE=y
+
+CONFIG_GPIO=y

--- a/boards/gd/scripts/gd32_peripheral_matrix.yaml
+++ b/boards/gd/scripts/gd32_peripheral_matrix.yaml
@@ -21,6 +21,7 @@ test_groups:
     boards:
       - gd32a503v_eval
       - gd32c231c_eval
+      - gd32c231k_start
       - gd32e103v_eval
       - gd32e507v_start
       - gd32e507z_eval


### PR DESCRIPTION
Add initial board support for GD32C231K-START, based on the GD32C231 SoC (ARM Cortex-M23, 64K flash, 12K RAM).

Supported features:
- GPIO
- UART
- pinmux
- LEDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for the GD32C231K-START development board with integrated UART console, GPIO control, and LED functionality for application development and testing.

* **Documentation**
  * Added comprehensive board documentation including hardware specifications, memory configuration (12KB RAM, 64KB flash), peripheral support details, pin assignments, and programming/debugging instructions.

* **Chores**
  * Integrated board configuration and test suite support for automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->