### PR TITLE
boards: gd: add GD32F303B-START board support

### DIFF
--- a/boards/gd/gd32f303b_start/Kconfig.gd32f303b_start
+++ b/boards/gd/gd32f303b_start/Kconfig.gd32f303b_start
@@ -1,0 +1,5 @@
+# Copyright (c) 2026, GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_GD32F303B_START
+	select SOC_GD32F303

--- a/boards/gd/gd32f303b_start/board.cmake
+++ b/boards/gd/gd32f303b_start/board.cmake
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+
+board_runner_args(jlink "--device=GD32F303CB" "--speed=4000")
+board_runner_args(gd32isp "--device=GD32F303CBT6")
+include(${ZEPHYR_BASE}/boards/common/gd32isp.board.cmake)

--- a/boards/gd/gd32f303b_start/board.yml
+++ b/boards/gd/gd32f303b_start/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: gd32f303b_start
+  full_name: GD32F303B-START
+  vendor: gd
+  socs:
+    - name: gd32f303

--- a/boards/gd/gd32f303b_start/doc/index.rst
+++ b/boards/gd/gd32f303b_start/doc/index.rst
@@ -1,0 +1,115 @@
+.. zephyr:board:: gd32f303b_start
+
+Overview
+********
+
+The GD32F303B-START board is a hardware platform for evaluating and developing
+applications on the GigaDevice GD32F303CBT6 MCU.
+
+The GD32F303CBT6 features a single-core ARM Cortex-M4F MCU running at up to
+120 MHz, with 128kiB of Flash, 32kiB of SRAM, and rich timer, UART, watchdog,
+PWM, ADC, and DAC peripherals.
+
+Hardware
+********
+
+- GD32F303CBT6 MCU
+- 2 x User LEDs
+- 1 x User button
+- 1 x USART for console
+- On-board GD-Link programmer/debugger
+- SWD debug interface
+
+For more information about the GD32F303 SoC and GD32F303B-START board:
+
+- `GigaDevice Cortex-M4 Mainstream SoC Website`_
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+Serial Port
+===========
+
+The GD32F303B-START board uses USART0 as the default serial console. TX is on
+PA9 and RX is on PA10 with a default baud rate of 115200.
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
+
+The board supports programming and debugging with the on-board GD-Link, an
+external J-Link, or the built-in ROM bootloader via ``gd32isp``.
+
+Using GD-Link or J-Link
+=======================
+
+#. Build the Zephyr kernel and the :zephyr:code-sample:`hello_world` sample
+   application:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: gd32f303b_start
+      :goals: build
+      :compact:
+
+#. Connect a serial adapter to PA9, PA10, and GND.
+
+#. Run your favorite terminal program to listen for output. On Linux the
+   terminal should be something like ``/dev/ttyUSB0``. For example:
+
+   .. code-block:: console
+
+      minicom -D /dev/ttyUSB0 -o
+
+   Configure the serial connection as follows:
+
+   - Speed: 115200
+   - Data: 8 bits
+   - Parity: None
+   - Stop bits: 1
+
+#. To flash an image:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: gd32f303b_start
+      :goals: flash
+      :compact:
+
+   When using J-Link, append ``--runner jlink`` after ``west flash``.
+
+#. To debug an image:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: gd32f303b_start
+      :goals: debug
+      :compact:
+
+   When using J-Link, append ``--runner jlink`` after ``west debug``.
+
+Using ROM bootloader
+====================
+
+The GD32F303 MCU includes a ROM bootloader which can be used with the
+``gd32isp`` runner.
+
+#. Build the application:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: gd32f303b_start
+      :goals: build
+      :compact:
+
+#. Flash the image with ``gd32isp``:
+
+   .. code-block:: console
+
+      west flash -r gd32isp [--port=/dev/ttyUSB0]
+
+.. _GigaDevice Cortex-M4 Mainstream SoC Website:
+   https://www.gigadevice.com/products/microcontrollers/gd32/arm-cortex-m4/mainstream-line/

--- a/boards/gd/gd32f303b_start/gd32f303b_start-pinctrl.dtsi
+++ b/boards/gd/gd32f303b_start/gd32f303b_start-pinctrl.dtsi
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026, GigaDevice Semiconductor Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pinctrl/gd32f303c(b)xx-pinctrl.h>
+
+&pinctrl {
+	usart0_default: usart0_default {
+		group1 {
+			pinmux = <USART0_TX_PA9_NORMP>, <USART0_RX_PA10_NORMP>;
+		};
+	};
+
+	pwm0_default: pwm0_default {
+		group1 {
+			pinmux = <TIMER0_CH0_PA8_NORMP>;
+		};
+	};
+};

--- a/boards/gd/gd32f303b_start/gd32f303b_start.dts
+++ b/boards/gd/gd32f303b_start/gd32f303b_start.dts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, GigaDevice Semiconductor Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/dts-v1/;
+
+#include <gd/gd32f30x/gd32f303.dtsi>
+#include "gd32f303b_start-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "GigaDevice GD32F303B-START";
+	compatible = "gd,gd32f303b-start";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,console = &usart0;
+		zephyr,shell-uart = &usart0;
+		zephyr,flash-controller = &fmc;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led1: led1 {
+			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
+			label = "LED1";
+		};
+
+		led2: led2 {
+			gpios = <&gpiob 15 GPIO_ACTIVE_HIGH>;
+			label = "LED2";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+
+		user_key: user_key {
+			label = "USER_KEY";
+			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		/* NOTE: bridge TIMER0_CH0 (PA8) and LED1 (PB14) */
+		pwm_led: pwm_led {
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	aliases {
+		led0 = &led1;
+		led1 = &led2;
+		sw0 = &user_key;
+		pwm-led0 = &pwm_led;
+		watchdog0 = &fwdgt;
+	};
+};
+
+/* GD32F303CBT6: 128KB Flash */
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(128)>;
+};
+
+&gpioa {
+	status = "okay";
+};
+
+&gpiob {
+	status = "okay";
+};
+
+&usart0 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+};
+
+&timer0 {
+	status = "okay";
+	prescaler = <256>;
+
+	pwm0: pwm {
+		status = "okay";
+		pinctrl-0 = <&pwm0_default>;
+		pinctrl-names = "default";
+	};
+};
+
+&fwdgt {
+	status = "okay";
+};

--- a/boards/gd/gd32f303b_start/gd32f303b_start.yaml
+++ b/boards/gd/gd32f303b_start/gd32f303b_start.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: gd32f303b_start
+name: GigaDevice GD32F303B-START
+type: mcu
+arch: arm
+ram: 32
+flash: 128
+toolchain:
+  - zephyr
+  - gnuarmemb
+supported:
+  - gpio
+  - uart
+  - watchdog
+  - pwm
+  - counter
+vendor: gd

--- a/boards/gd/gd32f303b_start/gd32f303b_start_defconfig
+++ b/boards/gd/gd32f303b_start/gd32f303b_start_defconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2026, GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ARM_MPU=y
+CONFIG_HW_STACK_PROTECTION=y
+
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_SERIAL=y
+
+CONFIG_GPIO=y

--- a/boards/gd/scripts/gd32_peripheral_matrix.yaml
+++ b/boards/gd/scripts/gd32_peripheral_matrix.yaml
@@ -24,6 +24,7 @@ test_groups:
       - gd32e103v_eval
       - gd32e507v_start
       - gd32e507z_eval
+      - gd32f303b_start
       - gd32f307c_eval
       - gd32f350r_eval
       - gd32f403z_eval
@@ -105,6 +106,7 @@ test_groups:
       - gd32a503v_eval
       - gd32e103v_eval
       - gd32e507z_eval
+      - gd32f303b_start
       - gd32f307c_eval
       - gd32f350r_eval
       - gd32f450i_eval

--- a/dts/arm/gd/gd32f30x/gd32f303.dtsi
+++ b/dts/arm/gd/gd32f30x/gd32f303.dtsi
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026, GigaDevice Semiconductor Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <freq.h>
+#include <gd/gd32f30x/gd32f30x.dtsi>
+
+&cpu0 {
+	clock-frequency = <DT_FREQ_M(120)>;
+};
+
+/* GD32F303CB: 128KB Flash, 32KB SRAM */
+/* The flash0 reg property will be set in the board dts file */
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(32)>;
+};
+
+&soc {
+	i2c0: i2c@40005400 {
+		compatible = "gd,gd32-i2c";
+		reg = <0x40005400 0x400>;
+		interrupts = <31 0>, <32 0>;
+		interrupt-names = "event", "error";
+		clocks = <&cctl GD32_CLOCK_I2C0>;
+		resets = <&rctl GD32_RESET_I2C0>;
+		status = "disabled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	i2c1: i2c@40005800 {
+		compatible = "gd,gd32-i2c";
+		reg = <0x40005800 0x400>;
+		interrupts = <33 0>, <34 0>;
+		interrupt-names = "event", "error";
+		clocks = <&cctl GD32_CLOCK_I2C1>;
+		resets = <&rctl GD32_RESET_I2C1>;
+		status = "disabled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	can0: can@40006400 {
+		compatible = "gd,gd32-can";
+		reg = <0x40006400 0x400>;
+		interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
+		interrupt-names = "tx", "rx0", "rx1", "sce";
+		clocks = <&cctl GD32_CLOCK_CAN0>;
+		resets = <&rctl GD32_RESET_CAN0>;
+		status = "disabled";
+	};
+
+	dac: dac@40007400 {
+		compatible = "gd,gd32-dac";
+		reg = <0x40007400 0x400>;
+		clocks = <&cctl GD32_CLOCK_DAC>;
+		resets = <&rctl GD32_RESET_DAC>;
+		status = "disabled";
+		num-channels = <2>;
+		#io-channel-cells = <1>;
+	};
+};

--- a/modules/hal_gigadevice/CMakeLists.txt
+++ b/modules/hal_gigadevice/CMakeLists.txt
@@ -79,6 +79,8 @@ endif()
 if(${CONFIG_SOC_SERIES_GD32F30X})
   if (${CONFIG_SOC_GD32F307})
     zephyr_compile_definitions(GD32F30X_CL)
+  elseif(${CONFIG_SOC_GD32F303})
+    zephyr_compile_definitions(GD32F30X_HD)
   endif()
 endif()
 

--- a/soc/gd/gd32/gd32f30x/Kconfig.defconfig.gd32f303
+++ b/soc/gd/gd32/gd32f30x/Kconfig.defconfig.gd32f303
@@ -1,0 +1,12 @@
+# Copyright (c) 2026, GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_GD32F303
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+
+config NUM_IRQS
+	default 68
+
+endif # SOC_GD32F303

--- a/soc/gd/gd32/gd32f30x/Kconfig.soc
+++ b/soc/gd/gd32/gd32f30x/Kconfig.soc
@@ -10,9 +10,14 @@ config SOC_SERIES_GD32F30X
 config SOC_SERIES
 	default "gd32f30x" if SOC_SERIES_GD32F30X
 
+config SOC_GD32F303
+	bool
+	select SOC_SERIES_GD32F30X
+
 config SOC_GD32F307
 	bool
 	select SOC_SERIES_GD32F30X
 
 config SOC
+	default "gd32f303" if SOC_GD32F303
 	default "gd32f307" if SOC_GD32F307

--- a/soc/gd/gd32/soc.yml
+++ b/soc/gd/gd32/soc.yml
@@ -30,6 +30,7 @@ family:
     - name: gd32f470
   - name: gd32f30x
     socs:
+    - name: gd32f303
     - name: gd32f307
   - name: gd32f403
     socs:


### PR DESCRIPTION
Add GD32F303 SoC definition and GD32F303B-START board with:
- GD32F303CBT6 (Cortex-M4F, 128KB Flash, 32KB SRAM)
- USART0 console on PA9/PA10
- 2x user LEDs (PB14, PB15)
- User key on PA0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the GigaDevice GD32F303B-START board (ARM Cortex-M4, 32 KB RAM, 128 KB flash)
  * Added GD32F303 SoC support with 120 MHz CPU setting
  * Exposed GPIO, UART (console), PWM LED, I2C, DAC, CAN, watchdog and timer peripherals with board pin mappings
  * Enabled ARM MPU, hardware stack protection, and serial console by default

* **Chores**
  * Added board metadata and build configuration for toolchains and defaults
<!-- end of auto-generated comment: release notes by coderabbit.ai -->