### PR TITLE
drivers: adc: gd32: add ADC DMA support for GD32H7xx and GD32H75E

### DIFF
--- a/boards/gd/gd32f503v_eval/gd32f503v_eval.dts
+++ b/boards/gd/gd32f503v_eval/gd32f503v_eval.dts
@@ -8,6 +8,7 @@
 
 #include <gd/gd32f50x/gd32f503vg.dtsi>
 #include "gd32f503v_eval-pinctrl.dtsi"
+#include <zephyr/dt-bindings/dma/gd32_dma.h>
 
 / {
 	model = "GigaDevice GD32F503V-EVAL";
@@ -71,6 +72,8 @@
 	status = "okay";
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
+	dmas = <&dmamux 8 5 (GD32_DMA_PERIPH_RX | GD32_DMA_PRIORITY_VERY_HIGH)>;
+	dma-names = "rx";
 	#address-cells = <1>;
 	#size-cells = <0>;
 
@@ -87,6 +90,8 @@
 	status = "okay";
 	pinctrl-0 = <&adc1_default>;
 	pinctrl-names = "default";
+	dmas = <&dmamux 9 66 (GD32_DMA_PERIPH_RX | GD32_DMA_PRIORITY_VERY_HIGH)>;
+	dma-names = "rx";
 	#address-cells = <1>;
 	#size-cells = <0>;
 

--- a/boards/gd/gd32h759i_eval/gd32h759i_eval-pinctrl.dtsi
+++ b/boards/gd/gd32h759i_eval/gd32h759i_eval-pinctrl.dtsi
@@ -25,9 +25,21 @@
 		};
 	};
 
-    adc0_default: adc0_default {
+	adc0_default: adc0_default {
 		group1 {
 			pinmux = <ADC012_IN12_PC2>;
+		};
+	};
+
+	adc1_default: adc1_default {
+		group1 {
+			pinmux = <ADC1_IN2_PF13>;
+		};
+	};
+
+	adc2_default: adc2_default {
+		group1 {
+			pinmux = <ADC2_IN5_PF3>;
 		};
 	};
 
@@ -40,7 +52,7 @@
 	pwm0_default: pwm0_default {
 		group1 {
 			pinmux = <TIMER0_CH0_PA8>, <TIMER0_MCH0_PA7>, <TIMER0_CH1_PE11>,
-					<TIMER0_MCH1_PB0>, <TIMER0_CH2_PA10>, <TIMER0_MCH2_PE12>;
+				 <TIMER0_MCH1_PB0>, <TIMER0_CH2_PA10>, <TIMER0_MCH2_PE12>;
 		};
 	};
 

--- a/boards/gd/gd32h759i_eval/gd32h759i_eval.dts
+++ b/boards/gd/gd32h759i_eval/gd32h759i_eval.dts
@@ -8,6 +8,7 @@
 
 #include <gd/gd32h7xx/gd32h759im.dtsi>
 #include "gd32h759i_eval-pinctrl.dtsi"
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/dma/gd32_dma.h>
 
 / {
@@ -26,9 +27,11 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led0 {
 			gpios = <&gpiof 10 GPIO_ACTIVE_HIGH>;
 		};
+
 		led1: led1 {
 			gpios = <&gpioa 6 GPIO_ACTIVE_HIGH>;
 		};
@@ -41,17 +44,19 @@
 		pwm_led0: pwm_led0 {
 			pwms = <&pwm1 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
+
 		pwm_led1: pwm_led1 {
 			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
+
 		pwm_led2: pwm_led2 {
 			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
+
 		pwm_led3: pwm_led3 {
 			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
-
 
 	aliases {
 		led0 = &led0;
@@ -63,6 +68,11 @@
 		pwm-led3 = &pwm_led3;
 		eeprom-0 = &eeprom0;
 	};
+
+	zephyr,user {
+		/* idx 0: ADC0 ch12 (PC2), idx 1: ADC1 ch2 (PF13), idx 2: ADC2 ch5 (PF3) */
+		io-channels = <&adc0 12>, <&adc1 2>, <&adc2 5>;
+	};
 };
 
 &timer0 {
@@ -72,6 +82,7 @@
 	counterdirection = <0x10>;
 	deadtime = <200>;                  /* 1.06us */
 	status = "okay";
+
 	pwm0: pwm {
 		status = "okay";
 		pinctrl-0 = <&pwm0_default>;
@@ -85,6 +96,7 @@
 	alignedmode = <0x00>;
 	counterdirection = <0x10>;
 	status = "okay";
+
 	pwm1: pwm {
 		status = "okay";
 		pinctrl-0 = <&pwm1_default>;
@@ -171,8 +183,57 @@
 	status = "okay";
 	pinctrl-0 = <&adc0_default>;
 	pinctrl-names = "default";
-	dmas = <&dma0 1 9 (3<<16) 0>;
+	dmas = <&dmamux 8 9 (GD32_DMA_PERIPH_RX | GD32_DMA_PRIORITY_VERY_HIGH)>;
 	dma-names = "rx";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@c {
+		reg = <12>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 5)>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};
+
+&adc1 {
+	status = "okay";
+	pinctrl-0 = <&adc1_default>;
+	pinctrl-names = "default";
+	dmas = <&dmamux 10 10 (GD32_DMA_PERIPH_RX | GD32_DMA_PRIORITY_VERY_HIGH)>;
+	dma-names = "rx";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 5)>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};
+
+&adc2 {
+	status = "okay";
+	pinctrl-0 = <&adc2_default>;
+	pinctrl-names = "default";
+	dmas = <&dmamux 9 123 (GD32_DMA_PERIPH_RX | GD32_DMA_PRIORITY_VERY_HIGH)>;
+	dma-names = "rx";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@5 {
+		reg = <5>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 5)>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
 };
 
 &dma0 {
@@ -195,6 +256,7 @@
 	       <&dmamux 3 44 (GD32_DMA_PERIPH_TX | GD32_DMA_PRIORITY_HIGH)>;
 	dma-names = "rx", "tx";
 	clock-frequency = <100000>;
+
 	eeprom0: eeprom@50 {
 		compatible = "atmel,at24";
 		reg = <0x50>;
@@ -235,6 +297,7 @@
 	dmas = <&dmamux 4 99 (GD32_DMA_PERIPH_RX | GD32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux 5 100 (GD32_DMA_PERIPH_TX | GD32_DMA_PRIORITY_HIGH)>;
 	dma-names = "rx", "tx";
+
 	nor_flash: gd25q16@0 {
 		compatible = "jedec,spi-nor";
 		size = <0x1000000>;

--- a/boards/gd/gd32h75ey_eval/gd32h75ey_eval-pinctrl.dtsi
+++ b/boards/gd/gd32h75ey_eval/gd32h75ey_eval-pinctrl.dtsi
@@ -31,6 +31,18 @@
 		};
 	};
 
+	adc1_default: adc1_default {
+		group1 {
+			pinmux = <ADC1_IN2_PF13>;
+		};
+	};
+
+	adc2_default: adc2_default {
+		group1 {
+			pinmux = <ADC2_IN4_PF5>;
+		};
+	};
+
 	dac_default: dac_default {
 		group1 {
 			pinmux = <DAC0_OUT0_PA4>;
@@ -41,7 +53,7 @@
 		group1 {
 			/* CH2 uses PE13 to avoid conflict with USART0_RX on PA10 */
 			pinmux = <TIMER0_CH0_PA8>, <TIMER0_MCH0_PA7>, <TIMER0_CH1_PE11>,
-					<TIMER0_MCH1_PB0>, <TIMER0_CH2_PE13>, <TIMER0_MCH2_PE12>;
+				 <TIMER0_MCH1_PB0>, <TIMER0_CH2_PE13>, <TIMER0_MCH2_PE12>;
 		};
 	};
 

--- a/boards/gd/gd32h75ey_eval/gd32h75ey_eval.dts
+++ b/boards/gd/gd32h75ey_eval/gd32h75ey_eval.dts
@@ -8,6 +8,7 @@
 
 #include <gd/gd32h75e/gd32h75eym.dtsi>
 #include "gd32h75ey_eval-pinctrl.dtsi"
+#include <zephyr/dt-bindings/adc/adc.h>
 #include <zephyr/dt-bindings/dma/gd32_dma.h>
 
 / {
@@ -26,14 +27,17 @@
 
 	leds {
 		compatible = "gpio-leds";
+
 		led0: led0 {
 			gpios = <&gpioc 3 GPIO_ACTIVE_HIGH>;
 			label = "LED3";
 		};
+
 		led1: led1 {
 			gpios = <&gpioc 4 GPIO_ACTIVE_HIGH>;
 			label = "LED4";
 		};
+
 		led2: led2 {
 			gpios = <&gpioc 5 GPIO_ACTIVE_HIGH>;
 			label = "LED5";
@@ -47,9 +51,11 @@
 		pwm_led1: pwm_led1 {
 			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
+
 		pwm_led2: pwm_led2 {
 			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
+
 		pwm_led3: pwm_led3 {
 			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
@@ -65,6 +71,11 @@
 		pwm-led3 = &pwm_led3;
 		eeprom-0 = &eeprom0;
 	};
+
+	zephyr,user {
+		/* idx 0: ADC0 ch12 (PC2), idx 1: ADC1 ch2 (PF13), idx 2: ADC2 ch4 (PF5) */
+		io-channels = <&adc0 12>, <&adc1 2>, <&adc2 4>;
+	};
 };
 
 &timer0 {
@@ -74,6 +85,7 @@
 	counterdirection = <0x10>;
 	deadtime = <200>;                  /* 1.06us */
 	status = "okay";
+
 	pwm0: pwm {
 		status = "okay";
 		pinctrl-0 = <&pwm0_default>;
@@ -170,6 +182,55 @@
 	pinctrl-names = "default";
 	dmas = <&dmamux 1 9 (GD32_DMA_PERIPH_RX | GD32_DMA_PRIORITY_VERY_HIGH)>;
 	dma-names = "rx";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@c {
+		reg = <12>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 5)>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};
+
+&adc1 {
+	status = "okay";
+	pinctrl-0 = <&adc1_default>;
+	pinctrl-names = "default";
+	dmas = <&dmamux 15 10 (GD32_DMA_PERIPH_RX | GD32_DMA_PRIORITY_VERY_HIGH)>;
+	dma-names = "rx";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 5)>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
+};
+
+&adc2 {
+	status = "okay";
+	pinctrl-0 = <&adc2_default>;
+	pinctrl-names = "default";
+	dmas = <&dmamux 14 123 (GD32_DMA_PERIPH_RX | GD32_DMA_PRIORITY_VERY_HIGH)>;
+	dma-names = "rx";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@4 {
+		reg = <4>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME(ADC_ACQ_TIME_TICKS, 5)>;
+		zephyr,resolution = <12>;
+		zephyr,vref-mv = <3300>;
+	};
 };
 
 &dma0 {
@@ -203,6 +264,7 @@
 	dmas = <&dmamux 0 184 (GD32_DMA_PERIPH_RX | GD32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux 1 185 (GD32_DMA_PERIPH_TX | GD32_DMA_PRIORITY_HIGH)>;
 	dma-names = "rx", "tx";
+
 	eeprom0: eeprom@50 {
 		compatible = "atmel,at24";
 		reg = <0x50>;
@@ -259,6 +321,7 @@
 	dmas = <&dmamux 12 99 (GD32_DMA_PERIPH_RX | GD32_DMA_PRIORITY_HIGH)>,
 	       <&dmamux 13 100 (GD32_DMA_PERIPH_TX | GD32_DMA_PRIORITY_HIGH)>;
 	dma-names = "rx", "tx";
+
 	nor_flash: gd25q16@0 {
 		compatible = "jedec,spi-nor";
 		size = <0x1000000>;

--- a/drivers/adc/Kconfig.gd32
+++ b/drivers/adc/Kconfig.gd32
@@ -9,6 +9,14 @@ config ADC_GD32
 	default y
 	depends on DT_HAS_GD_GD32_ADC_ENABLED
 	select PINCTRL
+	select USE_GD32_TRIGSEL if SOC_SERIES_GD32H7XX || SOC_SERIES_GD32H75E
 	select USE_GD32_ADC
 	help
 	  Enable GigaDevice GD32 ADC driver
+
+config ADC_GD32_DMA
+	bool "GD32 ADC DMA support"
+	select DMA
+	help
+	  Use DMA to transfer ADC regular conversion results for ADC nodes
+	  that define a "rx" dma channel in their device tree node.

--- a/drivers/adc/adc_gd32.c
+++ b/drivers/adc/adc_gd32.c
@@ -19,6 +19,31 @@
 
 #include <gd32_adc.h>
 #include <gd32_rcu.h>
+#if defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)
+#include <gd32_trigsel.h>
+#endif
+
+/*
+ * GD32H75E HAL uses "ROUTRG"/"ROUTINE" naming where GD32H7XX uses "REGTRG"/"REGULAR".
+ * Provide aliases so the shared init code below needs no per-SoC ifdefs.
+ */
+#if defined(CONFIG_SOC_SERIES_GD32H75E)
+#define TRIGSEL_OUTPUT_ADC0_REGTRG TRIGSEL_OUTPUT_ADC0_ROUTRG
+#define TRIGSEL_OUTPUT_ADC1_REGTRG TRIGSEL_OUTPUT_ADC1_ROUTRG
+#define TRIGSEL_OUTPUT_ADC2_REGTRG TRIGSEL_OUTPUT_ADC2_ROUTRG
+#define ADC_REGULAR_CHANNEL        ADC_ROUTINE_CHANNEL
+#endif
+
+#ifdef CONFIG_ADC_GD32_DMA
+#include <zephyr/drivers/dma.h>
+#include <zephyr/drivers/dma/dma_gd32.h>
+#if defined(CONFIG_CACHE_MANAGEMENT) && defined(CONFIG_DCACHE)
+#define ADC_GD32_DMA_CACHE_REQUIRED 1
+#include <gd32_cache.h>
+#else
+#define ADC_GD32_DMA_CACHE_REQUIRED 0
+#endif
+#endif
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
@@ -46,6 +71,13 @@ LOG_MODULE_REGISTER(adc_gd32, CONFIG_ADC_LOG_LEVEL);
 #define ADC1_ENABLE		DT_NODE_HAS_STATUS_OKAY(ADC1_NODE)
 #define ADC2_ENABLE		DT_NODE_HAS_STATUS_OKAY(ADC2_NODE)
 
+/* ADC0 and ADC1 share ADC0 SYNCCTL. ADC2 uses its own SYNCCTL. */
+#if (defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)) && \
+	ADC0_ENABLE && ADC1_ENABLE
+BUILD_ASSERT(DT_PROP(ADC0_NODE, rcu_clock_source) == DT_PROP(ADC1_NODE, rcu_clock_source),
+	     "ADC0 and ADC1 share ADC0 SYNCCTL; use the same rcu-clock-source");
+#endif
+
 #ifndef	ADC0
 /**
  * @brief The name of gd32 ADC HAL are different between single and multi ADC SoCs.
@@ -69,18 +101,24 @@ LOG_MODULE_REGISTER(adc_gd32, CONFIG_ADC_LOG_LEVEL);
 #endif
 
 #if defined(CONFIG_SOC_SERIES_GD32F50X)
-/*
- * GD32F50x multi-ADC HAL uses routine-sequence naming for the end-of-conversion
- * flag and its interrupt enable. Map the names used by this driver to them.
- */
+
 #define ADC_STAT_EOC   ADC_STAT_EORC
 #define ADC_CTL0_EOCIE ADC_CTL0_EORCIE
+#define adc_dma_request_after_last_enable(periph)
+#define adc_dma_mode_enable(periph) adc_dma_mode_enable(periph, ADC_ROUTINE_CHANNEL)
 #endif
 
 #define SPT_WIDTH   3U
 #define SAMPT1_SIZE 10U
-
-#if defined(CONFIG_SOC_SERIES_GD32F4XX)
+#if defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)
+#define ADC_GD32_H7_DEFAULT_SAMPLE_TIME       0U
+#define ADC_GD32_H7_ADC01_MIN_ACQ_TICKS       4U
+#define ADC_GD32_H7_ADC01_MAX_ACQ_TICKS       811U
+#define ADC_GD32_H7_ADC01_MAX_SAMPLE_TIME     807U
+#define ADC_GD32_H7_ADC2_MIN_ACQ_TICKS        3U
+#define ADC_GD32_H7_ADC2_MAX_ACQ_TICKS        641U
+#define ADC_GD32_H7_ADC2_MAX_SAMPLE_TIME      638U
+#elif defined(CONFIG_SOC_SERIES_GD32F4XX)
 #define SMP_TIME(x) ADC_SAMPLETIME_##x
 
 static const uint16_t acq_time_tbl[8] = {3, 15, 28, 56, 84, 112, 144, 480};
@@ -138,9 +176,32 @@ static const uint32_t table_samp_time[] = {
 };
 #endif
 
+#ifdef CONFIG_ADC_GD32_DMA
+enum adc_gd32_dma_direction {
+	RX = 0,
+	TX,
+	NUM_OF_DIRECTION
+};
+
+struct adc_gd32_dma_config {
+	const struct device *dev;
+	uint32_t channel;
+	uint32_t config;
+	uint32_t slot;
+	uint32_t fifo_threshold;
+};
+
+struct adc_gd32_dma_data {
+	struct dma_config config;
+	struct dma_block_config block;
+	uint32_t count;
+};
+#endif /* CONFIG_ADC_GD32_DMA */
+
 struct adc_gd32_config {
 	uint32_t reg;
-#if defined(CONFIG_SOC_SERIES_GD32F3X0) || defined(CONFIG_SOC_SERIES_GD32F50X)
+#if defined(CONFIG_SOC_SERIES_GD32F3X0) || defined(CONFIG_SOC_SERIES_GD32F50X) || \
+	defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)
 	uint32_t rcu_clock_source;
 #endif
 	uint16_t clkid;
@@ -149,6 +210,12 @@ struct adc_gd32_config {
 	const struct pinctrl_dev_config *pcfg;
 	uint8_t irq_num;
 	void (*irq_config_func)(void);
+#if defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)
+	uint32_t trigger_select;
+#endif
+#ifdef CONFIG_ADC_GD32_DMA
+	const struct adc_gd32_dma_config dma[NUM_OF_DIRECTION];
+#endif
 };
 
 struct adc_gd32_data {
@@ -156,7 +223,62 @@ struct adc_gd32_data {
 	const struct device *dev;
 	uint16_t *buffer;
 	uint16_t *repeat_buffer;
+#ifdef CONFIG_ADC_GD32_DMA
+	struct adc_gd32_dma_data dma[NUM_OF_DIRECTION];
+#endif
 };
+
+#ifdef CONFIG_ADC_GD32_DMA
+static void adc_gd32_dma_callback(const struct device *dma_dev, void *arg,
+				  uint32_t channel, int status);
+
+/* Configure and start the regular-group RX DMA channel. */
+static int adc_gd32_dma_setup(const struct device *dev, uint32_t dir)
+{
+	const struct adc_gd32_config *cfg = dev->config;
+	struct adc_gd32_data *data = dev->data;
+	struct dma_config *dma_cfg = &data->dma[dir].config;
+	struct dma_block_config *block_cfg = &data->dma[dir].block;
+	const struct adc_gd32_dma_config *dma = &cfg->dma[dir];
+	int ret;
+
+	memset(dma_cfg, 0, sizeof(struct dma_config));
+	memset(block_cfg, 0, sizeof(struct dma_block_config));
+
+	dma_cfg->source_burst_length = 1;
+	dma_cfg->dest_burst_length = 1;
+	dma_cfg->user_data = (void *)dev;
+	dma_cfg->dma_callback = adc_gd32_dma_callback;
+	dma_cfg->block_count = 1U;
+	dma_cfg->head_block = block_cfg;
+	dma_cfg->dma_slot = dma->slot;
+	dma_cfg->channel_priority = GD32_DMA_CONFIG_PRIORITY(dma->config);
+	dma_cfg->channel_direction = PERIPHERAL_TO_MEMORY;
+	dma_cfg->source_data_size = 2;
+	dma_cfg->dest_data_size = 2;
+	dma_cfg->cyclic = 1;
+
+	block_cfg->block_size = 1;
+	block_cfg->source_address = (uint32_t)&ADC_RDATA(cfg->reg);
+	block_cfg->source_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+	block_cfg->dest_address = (uint32_t)data->buffer;
+	block_cfg->dest_addr_adj = DMA_ADDR_ADJ_NO_CHANGE;
+
+	ret = dma_config(dma->dev, dma->channel, dma_cfg);
+	if (ret < 0) {
+		LOG_ERR("dma_config %p failed %d", dma->dev, ret);
+		return ret;
+	}
+
+	ret = dma_start(dma->dev, dma->channel);
+	if (ret < 0) {
+		LOG_ERR("dma_start %p failed %d", dma->dev, ret);
+		return ret;
+	}
+
+	return 0;
+}
+#endif /* CONFIG_ADC_GD32_DMA */
 
 static void adc_gd32_isr(const struct device *dev)
 {
@@ -192,8 +314,20 @@ static void adc_context_start_sampling(struct adc_context *ctx)
 	k_busy_wait(20);
 #endif
 
+#ifdef CONFIG_ADC_GD32_DMA
+	{
+		int ret = adc_gd32_dma_setup(dev, RX);
+
+		if (ret < 0) {
+			LOG_ERR("DMA setup failed: %d", ret);
+			adc_context_complete(&data->ctx, ret);
+			return;
+		}
+	}
+#else
 	/* Enable EOC interrupt */
 	ADC_CTL0(cfg->reg) |= ADC_CTL0_EOCIE;
+#endif
 
 	/* Set ADC software conversion trigger. */
 	ADC_CTL1(cfg->reg) |= ADC_CTL1_SWRCST;
@@ -227,9 +361,70 @@ static inline void adc_gd32_calibration(const struct adc_gd32_config *cfg)
 #endif
 }
 
+#if defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)
+static int adc_gd32_h7_sample_time_from_acq_time(const struct adc_gd32_config *cfg,
+						 uint16_t acq_time, uint16_t *sample_time)
+{
+	uint16_t min_acq_ticks;
+	uint16_t max_acq_ticks;
+	uint16_t max_sample_time;
+	uint16_t acq_ticks;
+
+	if (cfg->reg == ADC2) {
+		min_acq_ticks = ADC_GD32_H7_ADC2_MIN_ACQ_TICKS;
+		max_acq_ticks = ADC_GD32_H7_ADC2_MAX_ACQ_TICKS;
+		max_sample_time = ADC_GD32_H7_ADC2_MAX_SAMPLE_TIME;
+	} else {
+		min_acq_ticks = ADC_GD32_H7_ADC01_MIN_ACQ_TICKS;
+		max_acq_ticks = ADC_GD32_H7_ADC01_MAX_ACQ_TICKS;
+		max_sample_time = ADC_GD32_H7_ADC01_MAX_SAMPLE_TIME;
+	}
+
+	if (acq_time == ADC_ACQ_TIME_DEFAULT) {
+		*sample_time = ADC_GD32_H7_DEFAULT_SAMPLE_TIME;
+		return 0;
+	}
+
+	if (acq_time == ADC_ACQ_TIME_MAX) {
+		*sample_time = max_sample_time;
+		return 0;
+	}
+
+	if (ADC_ACQ_TIME_UNIT(acq_time) != ADC_ACQ_TIME_TICKS) {
+		LOG_ERR("Acquisition time expected in ticks");
+		return -EINVAL;
+	}
+
+	acq_ticks = ADC_ACQ_TIME_VALUE(acq_time);
+	if (acq_ticks < min_acq_ticks || acq_ticks > max_acq_ticks) {
+		LOG_ERR("Acquisition time %u ticks out of range %u..%u",
+			acq_ticks, min_acq_ticks, max_acq_ticks);
+		return -EINVAL;
+	}
+
+	*sample_time = acq_ticks - min_acq_ticks;
+
+	return 0;
+}
+#endif
+
 static int adc_gd32_configure_sampt(const struct adc_gd32_config *cfg,
 				    uint8_t channel, uint16_t acq_time)
 {
+#if defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)
+	uint16_t sample_time;
+	int ret;
+
+	ret = adc_gd32_h7_sample_time_from_acq_time(cfg, acq_time, &sample_time);
+	if (ret < 0) {
+		return ret;
+	}
+
+	/* Configure the routine sequence slot sample time directly. */
+	ADC_RSQ8(cfg->reg) = SQX_SMP(sample_time);
+
+	return 0;
+#else
 	uint8_t index = 0, offset;
 
 	if (acq_time != ADC_ACQ_TIME_DEFAULT) {
@@ -260,6 +455,7 @@ static int adc_gd32_configure_sampt(const struct adc_gd32_config *cfg,
 	}
 
 	return 0;
+#endif
 }
 
 static int adc_gd32_channel_setup(const struct device *dev,
@@ -291,6 +487,52 @@ static int adc_gd32_channel_setup(const struct device *dev,
 					chan_cfg->acquisition_time);
 }
 
+#if defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)
+static int adc_gd32_h7_resolution_id(const struct adc_gd32_config *cfg,
+				     uint8_t resolution, uint8_t *resolution_id)
+{
+	if (cfg->reg == ADC2) {
+		switch (resolution) {
+		case 12U:
+			*resolution_id = 0U;
+			break;
+		case 10U:
+			*resolution_id = 1U;
+			break;
+		case 8U:
+			*resolution_id = 2U;
+			break;
+		case 6U:
+			*resolution_id = 3U;
+			break;
+		default:
+			return -EINVAL;
+		}
+
+		return 0;
+	}
+
+	switch (resolution) {
+	case 14U:
+		*resolution_id = 0U;
+		break;
+	case 12U:
+		*resolution_id = 1U;
+		break;
+	case 10U:
+		*resolution_id = 2U;
+		break;
+	case 8U:
+		*resolution_id = 3U;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+#endif
+
 static int adc_gd32_start_read(const struct device *dev,
 			       const struct adc_sequence *sequence)
 {
@@ -305,6 +547,16 @@ static int adc_gd32_start_read(const struct device *dev,
 		return -ENOTSUP;
 	}
 
+#if defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)
+	{
+		int ret = adc_gd32_h7_resolution_id(cfg, sequence->resolution,
+						       &resolution_id);
+
+		if (ret < 0) {
+			return ret;
+		}
+	}
+#else
 	switch (sequence->resolution) {
 	case 12U:
 		resolution_id = 0U;
@@ -321,8 +573,12 @@ static int adc_gd32_start_read(const struct device *dev,
 	default:
 		return -EINVAL;
 	}
+#endif
 
-#if defined(CONFIG_SOC_SERIES_GD32F4XX) || defined(CONFIG_SOC_SERIES_GD32F3X0) || \
+#if defined(CONFIG_SOC_SERIES_GD32F4XX) || \
+	defined(CONFIG_SOC_SERIES_GD32H7XX) || \
+	defined(CONFIG_SOC_SERIES_GD32H75E) || \
+	defined(CONFIG_SOC_SERIES_GD32F3X0) || \
 	defined(CONFIG_SOC_SERIES_GD32L23X)
 	ADC_CTL0(cfg->reg) &= ~ADC_CTL0_DRES;
 	ADC_CTL0(cfg->reg) |= CTL0_DRES(resolution_id);
@@ -340,8 +596,13 @@ static int adc_gd32_start_read(const struct device *dev,
 	}
 
 	/* Single conversion mode with regular group. */
+#if defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)
+	ADC_RSQ8(cfg->reg) &= ~ADC_RSQX_RSQN;
+	ADC_RSQ8(cfg->reg) |= index;
+#else
 	ADC_RSQ2(cfg->reg) &= ~ADC_RSQX_RSQN;
 	ADC_RSQ2(cfg->reg) = index;
+#endif
 
 	data->buffer = sequence->buffer;
 
@@ -355,6 +616,16 @@ static int adc_gd32_read(const struct device *dev,
 {
 	struct adc_gd32_data *data = dev->data;
 	int error;
+
+#ifdef CONFIG_ADC_GD32_DMA
+#if ADC_GD32_DMA_CACHE_REQUIRED
+	/*
+	 * Clean and invalidate the destination buffer so no dirty cache line
+	 * is written back over the data the DMA will deposit there.
+	 */
+	gd32_cache_flush_and_invd_buf(sequence->buffer, sequence->buffer_size);
+#endif
+#endif
 
 	adc_context_lock(&data->ctx, false, NULL);
 	error = adc_gd32_start_read(dev, sequence);
@@ -379,13 +650,35 @@ static int adc_gd32_read_async(const struct device *dev,
 }
 #endif /* CONFIG_ADC_ASYNC */
 
-static DEVICE_API(adc, adc_gd32_driver_api) = {
-	.channel_setup = adc_gd32_channel_setup,
-	.read = adc_gd32_read,
-#ifdef CONFIG_ADC_ASYNC
-	.read_async = adc_gd32_read_async,
-#endif /* CONFIG_ADC_ASYNC */
-};
+/* adc_gd32_driver_api is defined per-instance in ADC_GD32_INIT to allow
+ * ref_internal to be read from the devicetree vref-mv property.
+ */
+
+#ifdef CONFIG_ADC_GD32_DMA
+static void adc_gd32_dma_callback(const struct device *dma_dev, void *arg,
+				  uint32_t channel, int status)
+{
+	const struct device *dev = (const struct device *)arg;
+	struct adc_gd32_data *data = dev->data;
+
+	ARG_UNUSED(dma_dev);
+	ARG_UNUSED(channel);
+
+	if (status < 0) {
+		LOG_ERR("DMA transfer error: %d", status);
+		adc_context_complete(&data->ctx, status);
+		return;
+	}
+
+#if ADC_GD32_DMA_CACHE_REQUIRED
+	/* Make the DMA-written conversion result visible to the CPU. */
+	gd32_cache_invalidate_buf(data->buffer, sizeof(*data->buffer));
+#endif
+
+	LOG_DBG("DMA done");
+	adc_context_on_sampling_done(&data->ctx, dev);
+}
+#endif /* CONFIG_ADC_GD32_DMA */
 
 static int adc_gd32_init(const struct device *dev)
 {
@@ -400,18 +693,53 @@ static int adc_gd32_init(const struct device *dev)
 		return ret;
 	}
 
-#if defined(CONFIG_SOC_SERIES_GD32F3X0) || defined(CONFIG_SOC_SERIES_GD32F50X)
-	/* Select adc clock source and its prescaler. */
-	rcu_adc_clock_config(cfg->rcu_clock_source);
-#endif
-
 	(void)clock_control_on(GD32_CLOCK_CONTROLLER,
 			       (clock_control_subsys_t)&cfg->clkid);
 
+#if defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)
+	if (cfg->reg == ADC1) {
+		uint16_t adc0_clkid = DT_CLOCKS_CELL(ADC0_NODE, id);
+
+		/* ADC1 has no local SYNCCTL register and uses ADC0 SYNCCTL. */
+		ret = clock_control_on(GD32_CLOCK_CONTROLLER,
+				       (clock_control_subsys_t)&adc0_clkid);
+	}
+#endif
+
 	(void)reset_line_toggle_dt(&cfg->reset);
 
-#if defined(CONFIG_SOC_SERIES_GD32F403) || \
-	defined(CONFIG_SOC_SERIES_GD32VF103) || \
+#if defined(CONFIG_SOC_SERIES_GD32F3X0) || defined(CONFIG_SOC_SERIES_GD32F50X)
+	rcu_adc_clock_config(cfg->rcu_clock_source);
+#endif
+
+#if defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)
+	adc_clock_config(cfg->reg, cfg->rcu_clock_source);
+
+	if (cfg->trigger_select == 0U) {
+		/* Software trigger: disable hardware external trigger. */
+		ADC_CTL1(cfg->reg) &= ~ADC_CTL1_ETMRC;
+		ADC_CTL1(cfg->reg) |= EXTERNAL_TRIGGER_DISABLE << 28U;
+	} else {
+		/* Route a TRIGSEL input source to the ADC regular trigger. */
+		rcu_periph_clock_enable(RCU_TRIGSEL);
+
+		if (cfg->reg == ADC0) {
+			trigsel_init(TRIGSEL_OUTPUT_ADC0_REGTRG,
+				     (trigsel_source_enum)cfg->trigger_select);
+		} else if (cfg->reg == ADC1) {
+			trigsel_init(TRIGSEL_OUTPUT_ADC1_REGTRG,
+				     (trigsel_source_enum)cfg->trigger_select);
+		} else if (cfg->reg == ADC2) {
+			trigsel_init(TRIGSEL_OUTPUT_ADC2_REGTRG,
+				     (trigsel_source_enum)cfg->trigger_select);
+		}
+
+		adc_external_trigger_config(cfg->reg, ADC_REGULAR_CHANNEL,
+					    EXTERNAL_TRIGGER_RISING);
+	}
+#endif
+
+#if defined(CONFIG_SOC_SERIES_GD32VF103) || \
 	defined(CONFIG_SOC_SERIES_GD32F3X0) || \
 	defined(CONFIG_SOC_SERIES_GD32L23X)
 	/* Set SWRCST as the regular channel external trigger. */
@@ -426,6 +754,11 @@ static int adc_gd32_init(const struct device *dev)
 	ADC_CTL1(cfg->reg) |= ADC_CTL1_ETSRC;
 	ADC_CTL1(cfg->reg) |= ADC_CTL1_ETERC;
 #endif
+
+#ifdef CONFIG_ADC_GD32_DMA
+	adc_dma_request_after_last_enable(cfg->reg);
+	adc_dma_mode_enable(cfg->reg);
+#endif /* CONFIG_ADC_GD32_DMA */
 
 	/* Enable ADC */
 	ADC_CTL1(cfg->reg) |= ADC_CTL1_ADCON;
@@ -443,7 +776,7 @@ static int adc_gd32_init(const struct device *dev)
 	static const struct device *const dev_##n = DEVICE_DT_INST_GET(n);			\
 	const struct adc_gd32_config *cfg_##n = dev_##n->config;				\
 												\
-	if ((cfg_##n->irq_num == active_irq) &&							\
+	if (cfg_##n->irq_num == (active_irq) &&							\
 		(ADC_CTL0(cfg_##n->reg) & ADC_CTL0_EOCIE)) {					\
 		adc_gd32_isr(dev_##n);								\
 	}
@@ -470,39 +803,90 @@ static void adc_gd32_global_irq_cfg(void)
 #if ADC0_ENABLE
 	/* Shared irq config default to adc0. */
 	IRQ_CONNECT(DT_IRQN(ADC0_NODE),
-		DT_IRQ(ADC0_NODE, priority),
-		adc_gd32_global_irq_handler,
-		DEVICE_DT_GET(ADC0_NODE),
-		0);
+		    DT_IRQ(ADC0_NODE, priority),
+		    adc_gd32_global_irq_handler,
+		    DEVICE_DT_GET(ADC0_NODE),
+		    0);
 	irq_enable(DT_IRQN(ADC0_NODE));
 #elif ADC1_ENABLE
 	IRQ_CONNECT(DT_IRQN(ADC1_NODE),
-		DT_IRQ(ADC1_NODE, priority),
-		adc_gd32_global_irq_handler,
-		DEVICE_DT_GET(ADC1_NODE),
-		0);
+		    DT_IRQ(ADC1_NODE, priority),
+		    adc_gd32_global_irq_handler,
+		    DEVICE_DT_GET(ADC1_NODE),
+		    0);
 	irq_enable(DT_IRQN(ADC1_NODE));
 #endif
 
-#if (ADC0_ENABLE || ADC1_ENABLE) && \
-	defined(CONFIG_SOC_SERIES_GD32F4XX)
-	/* gd32f4xx adc2 share the same irq number with adc0 and adc1. */
+#if (ADC0_ENABLE || ADC1_ENABLE) && defined(CONFIG_SOC_SERIES_GD32F4XX)
+	/* gd32f4xx adc2 shares the same irq number with adc0 and adc1. */
 #elif ADC2_ENABLE
 	IRQ_CONNECT(DT_IRQN(ADC2_NODE),
-		DT_IRQ(ADC2_NODE, priority),
-		adc_gd32_global_irq_handler,
-		DEVICE_DT_GET(ADC2_NODE),
-		0);
+		    DT_IRQ(ADC2_NODE, priority),
+		    adc_gd32_global_irq_handler,
+		    DEVICE_DT_GET(ADC2_NODE),
+		    0);
 	irq_enable(DT_IRQN(ADC2_NODE));
 #endif
 }
 
-#if defined(CONFIG_SOC_SERIES_GD32F3X0) || defined(CONFIG_SOC_SERIES_GD32F50X)
+#if defined(CONFIG_SOC_SERIES_GD32F3X0) || defined(CONFIG_SOC_SERIES_GD32F50X) || \
+	defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)
 #define ADC_CLOCK_SOURCE(n)									\
 	.rcu_clock_source = DT_INST_PROP(n, rcu_clock_source)
 #else
 #define ADC_CLOCK_SOURCE(n)
 #endif
+
+#if defined(CONFIG_SOC_SERIES_GD32H7XX) || defined(CONFIG_SOC_SERIES_GD32H75E)
+#define ADC_TRIGGER_SELECT(n)									\
+	.trigger_select = DT_INST_PROP(n, trigger_select),
+#else
+#define ADC_TRIGGER_SELECT(n)
+#endif
+
+#ifdef CONFIG_ADC_GD32_DMA
+/*
+ * DMA cell mapping based on binding type:
+ * - gd,gd32-dma (2 cells): channel, config
+ * - gd,gd32-dma-v1 (4 cells): channel, slot, config, fifo_threshold
+ * - gd,gd32-dmamux (3 cells): channel, slot, config
+ *
+ * Both gd,gd32-dma-v1 and gd,gd32-dmamux have 'slot' cell.
+ * Only gd,gd32-dma-v1 has 'fifo_threshold' cell.
+ * Standard gd,gd32-dma does NOT have 'slot' cell.
+ */
+#define DMA_IS_V1(idx, dir) \
+	DT_NODE_HAS_COMPAT(DT_INST_DMAS_CTLR_BY_NAME(idx, dir), gd_gd32_dma_v1)
+
+#define DMA_IS_DMAMUX(idx, dir) \
+	DT_NODE_HAS_COMPAT(DT_INST_DMAS_CTLR_BY_NAME(idx, dir), gd_gd32_dmamux)
+
+#define DMA_GET_SLOT(idx, dir) \
+	COND_CODE_1(DMA_IS_V1(idx, dir), \
+		(DT_INST_DMAS_CELL_BY_NAME(idx, dir, slot)), \
+		(COND_CODE_1(DMA_IS_DMAMUX(idx, dir), \
+			(DT_INST_DMAS_CELL_BY_NAME(idx, dir, slot)), (0))))
+
+#define DMA_INITIALIZER(idx, dir)							\
+	{										\
+		.dev = DEVICE_DT_GET(DT_INST_DMAS_CTLR_BY_NAME(idx, dir)),		\
+		.channel = DT_INST_DMAS_CELL_BY_NAME(idx, dir, channel),		\
+		.slot = DMA_GET_SLOT(idx, dir),						\
+		.config = DT_INST_DMAS_CELL_BY_NAME(idx, dir, config),			\
+		.fifo_threshold = COND_CODE_1(DMA_IS_V1(idx, dir),			\
+			(DT_INST_DMAS_CELL_BY_NAME(idx, dir, fifo_threshold)), (0)),	\
+	}
+
+#define DMAS_DECL(idx)									\
+	{										\
+		COND_CODE_1(DT_INST_DMAS_HAS_NAME(idx, rx),				\
+			    (DMA_INITIALIZER(idx, rx)), ({0})),				\
+	}
+
+#define ADC_DMA_DECL(n)	.dma = DMAS_DECL(n),
+#else
+#define ADC_DMA_DECL(n)
+#endif /* CONFIG_ADC_GD32_DMA */
 
 #define ADC_GD32_INIT(n)									\
 	PINCTRL_DT_INST_DEFINE(n);								\
@@ -519,12 +903,20 @@ static void adc_gd32_global_irq_cfg(void)
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),					\
 		.irq_num = DT_INST_IRQN(n),							\
 		.irq_config_func = adc_gd32_global_irq_cfg,					\
+		ADC_TRIGGER_SELECT(n)								\
+		ADC_DMA_DECL(n)									\
 		ADC_CLOCK_SOURCE(n)								\
+	};											\
+	static DEVICE_API(adc, adc_gd32_driver_api_##n) = {			\
+		.channel_setup = adc_gd32_channel_setup,					\
+		.read = adc_gd32_read,							\
+	IF_ENABLED(CONFIG_ADC_ASYNC, (.read_async = adc_gd32_read_async,))\
+		.ref_internal = DT_INST_PROP(n, vref_mv),					\
 	};											\
 	DEVICE_DT_INST_DEFINE(n,								\
 			      adc_gd32_init, NULL,						\
 			      &adc_gd32_data_##n, &adc_gd32_config_##n,				\
 			      POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,				\
-			      &adc_gd32_driver_api);						\
+			      &adc_gd32_driver_api_##n);				\
 
 DT_INST_FOREACH_STATUS_OKAY(ADC_GD32_INIT)

--- a/dts/arm/gd/gd32h75e/gd32h75e.dtsi
+++ b/dts/arm/gd/gd32h75e/gd32h75e.dtsi
@@ -6,6 +6,7 @@
 
 #include <freq.h>
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/gd32h7xx.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
@@ -149,9 +150,36 @@
 			compatible = "gd,gd32-adc-trigsel", "gd,gd32-adc";
 			reg = <0x40012400 0x100>;
 			interrupts = <18 0>;
+			rcu-clock-source = <GD32_ADC_CLK_SYNC_HCLK_DIV8>;
 			clocks = <&cctl GD32_CLOCK_ADC0>;
 			resets = <&rctl GD32_RESET_ADC0>;
 			channels = <16>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+			trigger-select = <0x0>;
+		};
+
+		adc1: adc@40012800 {
+			compatible = "gd,gd32-adc-trigsel", "gd,gd32-adc";
+			reg = <0x40012800 0x100>;
+			interrupts = <18 0>;
+			rcu-clock-source = <GD32_ADC_CLK_SYNC_HCLK_DIV8>;
+			clocks = <&cctl GD32_CLOCK_ADC1>;
+			resets = <&rctl GD32_RESET_ADC1>;
+			channels = <16>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+			trigger-select = <0x0>;
+		};
+
+		adc2: adc@40012c00 {
+			compatible = "gd,gd32-adc-trigsel", "gd,gd32-adc";
+			reg = <0x40012c00 0x100>;
+			interrupts = <127 0>;
+			rcu-clock-source = <GD32_ADC_CLK_SYNC_HCLK_DIV8>;
+			clocks = <&cctl GD32_CLOCK_ADC2>;
+			resets = <&rctl GD32_RESET_ADC2>;
+			channels = <17>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 			trigger-select = <0x0>;
@@ -306,7 +334,7 @@
 
 		pinctrl: pin-controller@58020000 {
 			compatible = "gd,gd32-pinctrl-af";
-			reg = <0x58020000 0x2C00>;
+			reg = <0x58020000 0x2c00>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "okay";
@@ -554,16 +582,16 @@
 			clocks = <&cctl GD32_CLOCK_DMAMUX>;
 			dma-channels = <16>;
 			dma-generators = <8>;
-			dma-requests= <189>;
+			dma-requests = <189>;
 			status = "disabled";
 		};
 
 		can0: can@4001a000 {
 			compatible = "gd,gd32-can";
 			reg = <0x4001a000 0x1000>;
-			interrupts = <179 0>, <180 0>, <181 0>, <182 0>,<183 0>, <184 0>, <185 0>;
+			interrupts = <179 0>, <180 0>, <181 0>, <182 0>, <183 0>, <184 0>, <185 0>;
 			interrupt-names = "WAKE_UP", "MESSAGE_BUFFER", "BUS_OFF", "ERROR",
-						 "FAST_ERROR", "TX_WARNING", "RX_WARNING";
+					  "FAST_ERROR", "TX_WARNING", "RX_WARNING";
 			clocks = <&cctl GD32_CLOCK_CAN0>;
 			status = "disabled";
 			sjw = <1>;
@@ -575,9 +603,9 @@
 		can1: can@4001b000 {
 			compatible = "gd,gd32-can";
 			reg = <0x4001b000 0x1000>;
-			interrupts = <186 0>, <187 0>, <188 0>, <189 0>,<190 0>, <191 0>, <192 0>;
+			interrupts = <186 0>, <187 0>, <188 0>, <189 0>, <190 0>, <191 0>, <192 0>;
 			interrupt-names = "WAKE_UP", "MESSAGE_BUFFER", "BUS_OFF", "ERROR",
-						 "FAST_ERROR", "TX_WARNING", "RX_WARNING";
+					  "FAST_ERROR", "TX_WARNING", "RX_WARNING";
 			clocks = <&cctl GD32_CLOCK_CAN1>;
 			status = "disabled";
 			sjw = <1>;
@@ -589,9 +617,9 @@
 		can2: can@4001c000 {
 			compatible = "gd,gd32-can";
 			reg = <0x4001c000 0x1000>;
-			interrupts = <193 0>, <194 0>, <195 0>, <196 0>,<197 0>, <198 0>, <199 0>;
+			interrupts = <193 0>, <194 0>, <195 0>, <196 0>, <197 0>, <198 0>, <199 0>;
 			interrupt-names = "WAKE_UP", "MESSAGE_BUFFER", "BUS_OFF", "ERROR",
-						 "FAST_ERROR", "TX_WARNING", "RX_WARNING";
+					  "FAST_ERROR", "TX_WARNING", "RX_WARNING";
 			clocks = <&cctl GD32_CLOCK_CAN2>;
 			status = "disabled";
 			sjw = <1>;

--- a/dts/arm/gd/gd32h7xx/gd32h7xx.dtsi
+++ b/dts/arm/gd/gd32h7xx/gd32h7xx.dtsi
@@ -6,11 +6,14 @@
 
 #include <freq.h>
 #include <arm/armv7-m.dtsi>
+#include <zephyr/dt-bindings/adc/adc.h>
+#include <zephyr/dt-bindings/adc/gd32h7xx.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/clock/gd32h7xx-clocks.h>
 #include <zephyr/dt-bindings/reset/gd32h7xx.h>
+
 / {
 	cpus {
 		#address-cells = <1>;
@@ -148,9 +151,36 @@
 			compatible = "gd,gd32-adc-trigsel", "gd,gd32-adc";
 			reg = <0x40012400 0x100>;
 			interrupts = <18 0>;
+			rcu-clock-source = <GD32_ADC_CLK_SYNC_HCLK_DIV8>;
 			clocks = <&cctl GD32_CLOCK_ADC0>;
 			resets = <&rctl GD32_RESET_ADC0>;
 			channels = <16>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+			trigger-select = <0x0>;
+		};
+
+		adc1: adc@40012800 {
+			compatible = "gd,gd32-adc-trigsel", "gd,gd32-adc";
+			reg = <0x40012800 0x100>;
+			interrupts = <18 0>;
+			rcu-clock-source = <GD32_ADC_CLK_SYNC_HCLK_DIV8>;
+			clocks = <&cctl GD32_CLOCK_ADC1>;
+			resets = <&rctl GD32_RESET_ADC1>;
+			channels = <16>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+			trigger-select = <0x0>;
+		};
+
+		adc2: adc@40012c00 {
+			compatible = "gd,gd32-adc-trigsel", "gd,gd32-adc";
+			reg = <0x40012c00 0x100>;
+			interrupts = <127 0>;
+			rcu-clock-source = <GD32_ADC_CLK_SYNC_HCLK_DIV8>;
+			clocks = <&cctl GD32_CLOCK_ADC2>;
+			resets = <&rctl GD32_RESET_ADC2>;
+			channels = <17>;
 			status = "disabled";
 			#io-channel-cells = <1>;
 			trigger-select = <0x0>;
@@ -303,9 +333,9 @@
 			status = "disabled";
 		};
 
-	pinctrl: pin-controller@58020000 {
+		pinctrl: pin-controller@58020000 {
 			compatible = "gd,gd32-pinctrl-af";
-			reg = <0x58020000 0x2C00>;
+			reg = <0x58020000 0x2c00>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "okay";
@@ -555,16 +585,16 @@
 			clocks = <&cctl GD32_CLOCK_DMAMUX>;
 			dma-channels = <16>;
 			dma-generators = <8>;
-			dma-requests= <189>;
+			dma-requests = <189>;
 			status = "disabled";
 		};
 
 		can0: can@4001a000 {
 			compatible = "gd,gd32-can";
 			reg = <0x4001a000 0x1000>;
-			interrupts = <179 0>, <180 0>, <181 0>, <182 0>,<183 0>, <184 0>, <185 0>;
+			interrupts = <179 0>, <180 0>, <181 0>, <182 0>, <183 0>, <184 0>, <185 0>;
 			interrupt-names = "WAKE_UP", "MESSAGE_BUFFER", "BUS_OFF", "ERROR",
-							 "FAST_ERROR", "TX_WARNING", "RX_WARNING";
+					  "FAST_ERROR", "TX_WARNING", "RX_WARNING";
 			clocks = <&cctl GD32_CLOCK_CAN0>;
 			status = "disabled";
 			sjw = <1>;
@@ -576,9 +606,9 @@
 		can1: can@4001b000 {
 			compatible = "gd,gd32-can";
 			reg = <0x4001b000 0x1000>;
-			interrupts = <186 0>, <187 0>, <188 0>, <189 0>,<190 0>, <191 0>, <192 0>;
+			interrupts = <186 0>, <187 0>, <188 0>, <189 0>, <190 0>, <191 0>, <192 0>;
 			interrupt-names = "WAKE_UP", "MESSAGE_BUFFER", "BUS_OFF", "ERROR",
-							 "FAST_ERROR", "TX_WARNING", "RX_WARNING";
+					  "FAST_ERROR", "TX_WARNING", "RX_WARNING";
 			clocks = <&cctl GD32_CLOCK_CAN1>;
 			status = "disabled";
 			sjw = <1>;
@@ -590,9 +620,9 @@
 		can2: can@4001c000 {
 			compatible = "gd,gd32-can";
 			reg = <0x4001c000 0x1000>;
-			interrupts = <193 0>, <194 0>, <195 0>, <196 0>,<197 0>, <198 0>, <199 0>;
+			interrupts = <193 0>, <194 0>, <195 0>, <196 0>, <197 0>, <198 0>, <199 0>;
 			interrupt-names = "WAKE_UP", "MESSAGE_BUFFER", "BUS_OFF", "ERROR",
-							 "FAST_ERROR", "TX_WARNING", "RX_WARNING";
+					  "FAST_ERROR", "TX_WARNING", "RX_WARNING";
 			clocks = <&cctl GD32_CLOCK_CAN2>;
 			status = "disabled";
 			sjw = <1>;

--- a/dts/bindings/adc/gd,gd32-adc.yaml
+++ b/dts/bindings/adc/gd,gd32-adc.yaml
@@ -41,6 +41,14 @@ properties:
     description: Number of external channels
     required: true
 
+  vref-mv:
+    type: int
+    default: 3300
+    description: |
+      Internal reference voltage in millivolts (VDDA).
+      Used by adc_ref_internal() for raw-to-millivolts conversion.
+      Defaults to 3300 mV if not specified.
+
   interrupts:
     required: true
 

--- a/include/zephyr/dt-bindings/adc/gd32h7xx.h
+++ b/include/zephyr/dt-bindings/adc/gd32h7xx.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 GigaDevice Semiconductor Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief GD32H7XX and GD32H75E ADC clock prescaler definitions
+ *
+ * Device Tree Bindings for GD32H7XX and GD32H75E ADC clock configurations.
+ * These definitions refer to ADC_CLK_* values from the corresponding ADC HAL.
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADC_GD32H7XX_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADC_GD32H7XX_H_
+
+/** Synchronous clock mode: ADC clock = HCLK / 2 */
+#define GD32_ADC_CLK_SYNC_HCLK_DIV2  0x00080000
+/** Synchronous clock mode: ADC clock = HCLK / 4 */
+#define GD32_ADC_CLK_SYNC_HCLK_DIV4  0x00090000
+/** Synchronous clock mode: ADC clock = HCLK / 6 */
+#define GD32_ADC_CLK_SYNC_HCLK_DIV6  0x000A0000
+/** Synchronous clock mode: ADC clock = HCLK / 8 */
+#define GD32_ADC_CLK_SYNC_HCLK_DIV8  0x000B0000
+/** Synchronous clock mode: ADC clock = HCLK / 10 */
+#define GD32_ADC_CLK_SYNC_HCLK_DIV10 0x000C0000
+/** Synchronous clock mode: ADC clock = HCLK / 12 */
+#define GD32_ADC_CLK_SYNC_HCLK_DIV12 0x000D0000
+/** Synchronous clock mode: ADC clock = HCLK / 14 */
+#define GD32_ADC_CLK_SYNC_HCLK_DIV14 0x000E0000
+/** Synchronous clock mode: ADC clock = HCLK / 16 */
+#define GD32_ADC_CLK_SYNC_HCLK_DIV16 0x000F0000
+
+/** Asynchronous clock mode: ADC clock = async_clk / 1 */
+#define GD32_ADC_CLK_ASYNC_DIV1   0x00000000
+/** Asynchronous clock mode: ADC clock = async_clk / 2 */
+#define GD32_ADC_CLK_ASYNC_DIV2   0x00100000
+/** Asynchronous clock mode: ADC clock = async_clk / 4 */
+#define GD32_ADC_CLK_ASYNC_DIV4   0x00200000
+/** Asynchronous clock mode: ADC clock = async_clk / 6 */
+#define GD32_ADC_CLK_ASYNC_DIV6   0x00300000
+/** Asynchronous clock mode: ADC clock = async_clk / 8 */
+#define GD32_ADC_CLK_ASYNC_DIV8   0x00400000
+/** Asynchronous clock mode: ADC clock = async_clk / 10 */
+#define GD32_ADC_CLK_ASYNC_DIV10  0x00500000
+/** Asynchronous clock mode: ADC clock = async_clk / 12 */
+#define GD32_ADC_CLK_ASYNC_DIV12  0x00600000
+/** Asynchronous clock mode: ADC clock = async_clk / 16 */
+#define GD32_ADC_CLK_ASYNC_DIV16  0x00700000
+/** Asynchronous clock mode: ADC clock = async_clk / 32 */
+#define GD32_ADC_CLK_ASYNC_DIV32  0x00800000
+/** Asynchronous clock mode: ADC clock = async_clk / 64 */
+#define GD32_ADC_CLK_ASYNC_DIV64  0x00900000
+/** Asynchronous clock mode: ADC clock = async_clk / 128 */
+#define GD32_ADC_CLK_ASYNC_DIV128 0x00A00000
+/** Asynchronous clock mode: ADC clock = async_clk / 256 */
+#define GD32_ADC_CLK_ASYNC_DIV256 0x00B00000
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_GD32H7XX_H_ */

--- a/samples/drivers/adc/adc_dt/boards/gd32f503v_eval.conf
+++ b/samples/drivers/adc/adc_dt/boards/gd32f503v_eval.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+#CONFIG_ADC_GD32_DMA=y

--- a/samples/drivers/adc/adc_dt/boards/gd32h759i_eval.conf
+++ b/samples/drivers/adc/adc_dt/boards/gd32h759i_eval.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ADC_GD32_DMA=y

--- a/samples/drivers/adc/adc_dt/boards/gd32h75ey_eval.conf
+++ b/samples/drivers/adc/adc_dt/boards/gd32h75ey_eval.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ADC_GD32_DMA=y


### PR DESCRIPTION
git commit -s -m "drivers: adc: gd32: add ADC DMA support for GD32H7xx and GD32H75E" -m "The GD32H7xx and GD32H75E platforms require DMA-based ADC transfers
to achieve efficient continuous sampling without CPU intervention.
This adds the necessary driver implementation, DMA channel mapping,
device tree bindings, and board overlay for gd32h75ey_eval."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional DMA-driven ADC regular conversions via `ADC_GD32_DMA` (ADC device tree nodes must provide an `rx` DMA channel).
  * Added `vref-mv` device-tree property (default: 3300 mV) for internal reference scaling.
* **Improvements**
  * Enhanced ADC trigger selection and regular conversion sequencing for GD32H7XX/GD32H75E (software vs hardware triggering).
  * Enabled additional ADC peripherals on supported GD32 boards (ADC1/ADC2) with matching pin configuration and DMA RX setup.
  * Updated ADC DMA routing for the GD32H759i evaluation configuration and cleaned up device-tree formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->