### PR TITLE
driver: gd: add CAN peripheral update for gd32

### DIFF
--- a/boards/gd/gd32c113v_eval/gd32c113v_eval-pinctrl.dtsi
+++ b/boards/gd/gd32c113v_eval/gd32c113v_eval-pinctrl.dtsi
@@ -83,13 +83,18 @@
 		};
 	};
 
-		can0_default: can0_default {
+	can0_default: can0_default {
 		group1 {
-			pinmux = <CAN0_RX_PD0_FRMP>, <CAN0_TX_PD1_FRMP>;
+			pinmux = <CAN0_RX_PD0_FRMP>;
+			bias-pull-up;
+		};
+
+		group2 {
+			pinmux = <CAN0_TX_PD1_FRMP>;
 		};
 	};
 
-		can1_default: can1_default {
+	can1_default: can1_default {
 		group1 {
 			pinmux = <CAN1_RX_PB5_RMP>, <CAN1_TX_PB6_RMP>;
 		};

--- a/drivers/can/can_gd32.c
+++ b/drivers/can/can_gd32.c
@@ -1002,7 +1002,7 @@ static int can_gd32_send(const struct device *dev, const struct can_frame *frame
 	if ((frame->flags & CAN_FRAME_RTR) != 0) {
 		TxMail->CANX_TMI |= CAN_TMI_FT;
 	}
-	TxMail->CANX_TMP &= ~(CAN_TMP_DLENC | CAN_TMP_ESI | CAN_TMP_FDF);
+	TxMail->CANX_TMP &= ~(CAN_TMP_DLENC | CAN_TMP_ESI | CAN_TMP_FDF | CAN_TMP_TSEN);
 	TxMail->CANX_TMP |= (frame->dlc & 0xF);
 
 #ifdef CONFIG_CAN_FD_MODE
@@ -1259,7 +1259,7 @@ static void can_gd32_remove_rx_filter(const struct device *dev, int filter_id)
 	k_mutex_unlock(&filter_mutex);
 }
 
-static const struct can_driver_api can_api_funcs = {
+static DEVICE_API(can, can_api_funcs) = {
 	/* Get CAN work mode. */
 	.get_capabilities = can_gd32_get_capabilities,
 	/* Leave initialization mode. */
@@ -1363,9 +1363,10 @@ static const struct can_driver_api can_api_funcs = {
 #define CAN_GD32_DATA_INST(inst) static struct can_gd32_data can_gd32_dev_data_##inst;
 
 #define CAN_GD32_DEFINE_INST(inst)                                                                 \
-	DEVICE_DT_INST_DEFINE(inst, &can_gd32_init, NULL, &can_gd32_dev_data_##inst,               \
-			      &can_gd32_cfg_##inst, POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,         \
-			      &can_api_funcs);
+	CAN_DEVICE_DT_INST_DEFINE(inst, &can_gd32_init, NULL,                                      \
+				  &can_gd32_dev_data_##inst, &can_gd32_cfg_##inst,                 \
+				  POST_KERNEL, CONFIG_CAN_INIT_PRIORITY,                           \
+				  &can_api_funcs);
 
 #define CAN_GD32_INST(inst)                                                                        \
 	CAN_GD32_IRQ_INST(inst)                                                                    \

--- a/dts/arm/gd/gd32c11x/gd32c11x.dtsi
+++ b/dts/arm/gd/gd32c11x/gd32c11x.dtsi
@@ -205,7 +205,7 @@
 
 		wwdgt: watchdog@40002c00 {
 			compatible = "gd,gd32-wwdgt";
-			reg = <0x40002C00 0x400>;
+			reg = <0x40002c00 0x400>;
 			clocks = <&cctl GD32_CLOCK_WWDGT>;
 			resets = <&rctl GD32_RESET_WWDGT>;
 			interrupts = <0 0>;
@@ -540,6 +540,7 @@
 			#dma-cells = <2>;
 			status = "disabled";
 		};
+
 		can0: can@40006400 {
 			compatible = "gd,gd32-can";
 			reg = <0x40006400 0x400>;

--- a/tests/drivers/can/api/boards/gd32f503v_eval.conf
+++ b/tests/drivers/can/api/boards/gd32f503v_eval.conf
@@ -12,5 +12,3 @@
 # ZTEST_USER cases in supervisor mode on this board by not enabling userspace.
 
 CONFIG_TEST_USERSPACE=n
-CONFIG_CAN_RX_TIMESTAMP=n
-CONFIG_PM_DEVICE=n


### PR DESCRIPTION
Add CAN peripheral update for gd32.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CAN bus transmission handling with improved TX mailbox flag management to ensure reliable frame transmission

* **Chores**
  * Modernized CAN driver API registration and initialization methods for improved code consistency
  * Refined CAN pin control configuration with added pull-up bias support
  * Updated test environment configuration for evaluation boards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->