### PR TITLE
drivers: exit: gd32: add idempotent callback registration check

### DIFF
--- a/drivers/interrupt_controller/intc_gd32_exti.c
+++ b/drivers/interrupt_controller/intc_gd32_exti.c
@@ -202,6 +202,10 @@ int gd32_exti_configure(uint8_t line, gd32_exti_cb_t cb, void *user)
 	__ASSERT_NO_MSG(line < NUM_EXTI_LINES);
 	__ASSERT_NO_MSG(line2irq[line] != EXTI_NOTSUP);
 
+	if ((data->cbs[line].cb == cb) && (data->cbs[line].user == user)) {
+		return 0;
+	}
+
 	if ((data->cbs[line].cb != NULL) && (cb != NULL)) {
 		return -EALREADY;
 	}

--- a/include/zephyr/drivers/interrupt_controller/gd32_exti.h
+++ b/include/zephyr/drivers/interrupt_controller/gd32_exti.h
@@ -61,7 +61,7 @@ void gd32_exti_trigger(uint8_t line, uint8_t trigger);
  * @param user User data (optional).
  *
  * @retval 0 On success.
- * @retval -EALREADY If callback is already set and @p cb is not NULL.
+ * @retval -EALREADY If a different callback is already set and @p cb is not NULL.
  */
 int gd32_exti_configure(uint8_t line, gd32_exti_cb_t cb, void *user);
 


### PR DESCRIPTION
Allow repeated registration of same callback; only reject conflicting ones with -EALREADY.

Signed-off-by: Yuanshuo Chen yuanshuo.chen@gigadevice.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interrupt line configuration handling to allow safe reconfiguration when the same callback and user data are already set, avoiding erroneous “already configured” errors.
* **Documentation**
  * Clarified the documented conditions for when `-EALREADY` is returned during interrupt handler configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->