### PR TITLE
GD32F527: add tests overlay

### DIFF
--- a/boards/gd/gd32f527i_eval/board.cmake
+++ b/boards/gd/gd32f527i_eval/board.cmake
@@ -1,8 +1,11 @@
-# Copyright (c) 2025 GigaDevice Semiconductor Inc.
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
 # SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(pyocd "--target=GD32F527IS" "--frequency=4000000" "--tool-opt=--pack=${ZEPHYR_HAL_GIGADEVICE_MODULE_DIR}/${CONFIG_SOC_SERIES}/support/GigaDevice.GD32F527_DFP.1.4.0.pack")
 
 # GD32F527xx series is not yet supported by SEGGER J-Link
 board_runner_args(jlink "--device=GD32F527IS" "--speed=4000")
 
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/gd/gd32f527i_eval/doc/index.rst
+++ b/boards/gd/gd32f527i_eval/doc/index.rst
@@ -1,0 +1,86 @@
+.. zephyr:board:: gd32f527i_eval
+
+Overview
+********
+
+The GD32F527I-EVAL board is a hardware platform for prototyping with the
+GigaDevice GD32F527IS Cortex-M33F MCU.
+
+The Zephyr board configuration enables the GD32F527IS SoC, USART0 console,
+GPIO, I2C, SPI, DMA, pin control, and clock control support.
+
+Hardware
+********
+
+The following hardware is described by the current Zephyr board files:
+
+- GD32F527IS MCU
+- 512 KiB SRAM
+- LED0 connected to PF7
+- USART0 console with TX on PA9 and RX on PA10
+- AT24-compatible EEPROM on I2C0 at address 0x50
+- GD25Q16-compatible SPI NOR flash on SPI5
+- DMA support for enabled I2C, USART, and SPI peripherals
+
+Supported Features
+==================
+
+.. zephyr:board-supported-hw::
+
+Serial Port
+===========
+
+The default serial console is USART0. The board pin control configuration
+connects USART0 TX to PA9 and USART0 RX to PA10. The default baud rate is
+115200 bit/s.
+
+Programming and Debugging
+*************************
+
+.. zephyr:board-supported-runners::
+
+``west flash`` is currently supported through pyOCD with GD-Link. The required
+GD32F527 DFP pack is provided by the GigaDevice HAL module, so no extra setup is
+needed beyond installing pyOCD and connecting the GD-Link probe.
+
+Build the Zephyr kernel and the :zephyr:code-sample:`hello_world` sample
+application:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: gd32f527i_eval
+   :goals: build
+   :compact:
+
+Run your favorite terminal program to listen for output. On Linux the terminal
+should be something like ``/dev/ttyUSB0``. For example:
+
+.. code-block:: console
+
+   minicom -D /dev/ttyUSB0 -o
+
+The -o option tells minicom not to send the modem initialization string.
+Connection should be configured as follows:
+
+- Speed: 115200
+- Data: 8 bits
+- Parity: None
+- Stop bits: 1
+
+To flash an image:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: gd32f527i_eval
+   :goals: flash
+   :compact:
+
+You should see "Hello World! gd32f527i_eval" in your terminal.
+
+To debug an image:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :board: gd32f527i_eval
+   :goals: debug
+   :compact:

--- a/boards/gd/gd32f527i_eval/gd32f527i_eval.yaml
+++ b/boards/gd/gd32f527i_eval/gd32f527i_eval.yaml
@@ -17,3 +17,6 @@ supported:
   - usart
   - pinctrl
   - clock_control
+  - spi
+  - dma
+  - i2c

--- a/tests/drivers/flash/common/boards/gd32f527i_eval.conf
+++ b/tests/drivers/flash/common/boards/gd32f527i_eval.conf
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SPI=y
+CONFIG_SPI_NOR=y
+
+# The GD32 SPI driver registers a deinit handler; reference it to avoid an
+# unused-function build error (-Werror) when the SPI NOR device is released.
+CONFIG_DEVICE_DEINIT_SUPPORT=y
+
+# gd25q16 SPI NOR is 16 Mbit = 2 MB; enable flash_get_size verification so
+# the get_size test runs (PASS) instead of being skipped.
+CONFIG_TEST_DRIVER_FLASH_SIZE=2097152

--- a/tests/drivers/flash/common/boards/gd32f527i_eval.overlay
+++ b/tests/drivers/flash/common/boards/gd32f527i_eval.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 GigaDevice Semiconductor Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&nor_flash {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* 64KB storage partition at the end of the 2MB flash. */
+		storage_partition: partition@1f0000 {
+			label = "storage";
+			reg = <0x001f0000 DT_SIZE_K(64)>;
+		};
+	};
+};

--- a/tests/drivers/gpio/gpio_api_1pin/boards/gd32f527i_eval.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/gd32f527i_eval.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 GigaDevice Semiconductor Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		led0 = &test_gpio_led0;
+	};
+
+	test_gpio_leds {
+		compatible = "gpio-leds";
+
+		test_gpio_led0: test_gpio_led0 {
+			gpios = <&gpioc 0 GPIO_ACTIVE_LOW>;
+			label = "TEST GPIO LED0";
+		};
+	};
+};
+
+&gpioc {
+	status = "okay";
+};

--- a/tests/drivers/gpio/gpio_basic_api/boards/gd32f527i_eval.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/gd32f527i_eval.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 GigaDevice Semiconductor Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+		/* Bridge PE7 (out) to PE8 (in) for 2-pin GPIO loopback test. */
+		out-gpios = <&gpioe 7 0>;
+		in-gpios = <&gpioe 8 0>;
+	};
+};
+
+&gpioe {
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_loopback/boards/gd32f527i_eval.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/gd32f527i_eval.overlay
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 GigaDevice Semiconductor Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/dma/gd32_dma.h>
+
+/ {
+	zephyr,user {
+		/* PI3 (MOSI) is shorted to PI2 (MISO) for the deinit test. */
+		mosi-gpios = <&gpioi 3 GPIO_ACTIVE_HIGH>;
+		miso-gpios = <&gpioi 2 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&pinctrl {
+	spi1_default: spi1_default {
+		group1 {
+			pinmux = <SPI1_SCK_PI1>, <SPI1_MOSI_PI3>,
+				 <SPI1_MISO_PI2>;
+			slew-rate = "max-speed-50mhz";
+		};
+	};
+};
+
+&spi1 {
+	status = "okay";
+	pinctrl-0 = <&spi1_default>;
+	pinctrl-names = "default";
+	cs-gpios = <&gpioi 0 GPIO_ACTIVE_LOW>;
+
+	dmas = <&dma0 0 0 (GD32_DMA_PERIPH_RX | GD32_DMA_PRIORITY_HIGH) 0>,
+	       <&dma0 3 0 (GD32_DMA_PERIPH_TX | GD32_DMA_PRIORITY_HIGH) 0>;
+	dma-names = "rx", "tx";
+
+	slow@0 {
+		compatible = "test-spi-loopback-slow";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+
+	fast@0 {
+		compatible = "test-spi-loopback-fast";
+		reg = <0>;
+		spi-max-frequency = <16000000>;
+	};
+};
+
+&gpioi {
+	status = "okay";
+};
+
+&dma0 {
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -195,6 +195,7 @@ tests:
       - gd32f450v_start
       - gd32f450z_eval
       - gd32f470i_eval
+      - gd32f527i_eval
       - gd32vf103c_starter
       - gd32vf103v_eval
       - longan_nano

--- a/tests/drivers/uart/uart_async_api/boards/gd32f527i_eval.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/gd32f527i_eval.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 GigaDevice Semiconductor Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/dt-bindings/dma/gd32_dma.h>
+#include <dt-bindings/pinctrl/gd32f527i(m-s)xx-pinctrl.h>
+
+&pinctrl {
+	usart1_default: usart1_default {
+		group1 {
+			pinmux = <USART1_TX_PA2>, <USART1_RX_PA3>;
+		};
+	};
+};
+
+dut: &usart1 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&usart1_default>;
+	pinctrl-names = "default";
+	dmas = <&dma0 6 4 (GD32_DMA_PERIPH_TX | GD32_DMA_PRIORITY_HIGH) 0>,
+	       <&dma0 5 4 (GD32_DMA_PERIPH_RX | GD32_DMA_PRIORITY_HIGH) 0>;
+	dma-names = "tx", "rx";
+};
+
+&dma0 {
+	status = "okay";
+};


### PR DESCRIPTION
Including:
- Improve GD32F527 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Zephyr documentation for the `gd32f527i_eval` board, including supported hardware, serial console defaults, and `west flash` workflows.
  - Improved programming/debugging configuration for pyOCD by linking the required device pack and board runner settings.
  - Expanded board capabilities to include SPI, DMA, and I2C.

- **Tests**
  - Added board overlays/configurations to support SPI-NOR flash, GPIO tests, SPI loopback, and asynchronous UART DMA testing.
  - Enabled the `gd32f527i_eval` platform for the SPI loopback test case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->