### PR TITLE
gd32e508: add can support

### DIFF
--- a/boards/gd/gd32e508z_eval/Kconfig.gd32e508z_eval
+++ b/boards/gd/gd32e508z_eval/Kconfig.gd32e508z_eval
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_GD32E508Z_EVAL
+	select SOC_GD32E508

--- a/boards/gd/gd32e508z_eval/board.cmake
+++ b/boards/gd/gd32e508z_eval/board.cmake
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(pyocd
+  "--target=GD32E508ZE"
+  "--frequency=4000000"
+  "--tool-opt=--pack=${ZEPHYR_HAL_GIGADEVICE_MODULE_DIR}/${CONFIG_SOC_SERIES}/support/GigaDevice.GD32E50x_DFP.1.9.0.pack"
+)
+board_runner_args(
+  jlink
+  "--device=GD32E508ZE" "--iface=jtag" "--tool-opt=-JTAGConf -1,-1"
+)
+
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/gd/gd32e508z_eval/board.yml
+++ b/boards/gd/gd32e508z_eval/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: gd32e508z_eval
+  full_name: GD32E508Z-EVAL
+  vendor: gd
+  socs:
+    - name: gd32e508

--- a/boards/gd/gd32e508z_eval/doc/index.rst
+++ b/boards/gd/gd32e508z_eval/doc/index.rst
@@ -1,0 +1,144 @@
+.. zephyr:board:: gd32e508z_eval
+
+GigaDevice GD32E508Z-EVAL
+#########################
+
+Overview
+********
+
+The GD32E508Z-EVAL board is a hardware platform that enables prototyping
+on GD32E508ZE Cortex-M33 High Performance MCU.
+
+The GD32E508ZE features a single-core ARM Cortex-M33 MCU which can run up
+to 180 MHz with flash accesses zero wait states, 512kiB of Flash, 128kiB of
+SRAM and 112 GPIOs.
+
+Hardware
+********
+
+- GD32E508ZET6 MCU
+- AT24C02C 2Kb EEPROM
+- GD25Q16 16Mbit SPI and QSPI NOR Flash
+- GD9FU1G8F2A 1Gbit NAND Flash
+- Micron MT48LC16M16A2P-6AIT 256Mbit SDRAM
+- 4 x User LEDs
+- 1 x Joystick (L/R/U/D/C)
+- 1 x USART (connected to USB VCOM at J1 connector)
+- 1 x POT connected to an ADC input
+- Headphone interface
+- USB FS connector
+- 3 x CAN (includes SN65HVD230 PHY)
+- Ethernet Interface
+- 3.2" RGB-LCD (320x240)
+- GD-Link on board programmer
+- J-Link/JTAG connector
+
+For more information about the GD32E508 SoC and GD32E508Z-EVAL board:
+
+- `GigaDevice GD32E508 Product Page`_
+- `GD32E50X User Manual`_
+
+Supported Features
+==================
+
+The board configuration supports the following hardware features:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Peripheral
+     - Kconfig option
+     - Devicetree compatible
+   * - CAN
+     - :kconfig:option:`CONFIG_CAN`
+     - :dtcompatible:`gd,gd32-can`
+   * - USART
+     - :kconfig:option:`CONFIG_SERIAL`
+     - :dtcompatible:`gd,gd32-usart`
+
+Serial Port
+===========
+
+The GD32E508Z-EVAL board has one serial communication port. The default port
+is USART0 with TX connected at PA9 and RX at PA10. USART0 is exposed as a
+virtual COM port via the J1 USB connector.
+
+CAN
+===
+
+The GD32E508Z-EVAL board exposes CAN0 (zephyr,canbus) with RX at PD0 and TX at
+PD1. The on-board SN65HVD230 transceiver is used as the CAN PHY.
+
+Programming and Debugging
+*************************
+
+Before programming your board make sure to configure boot jumpers as
+follows:
+
+- JP3/4: Select 2-3 for both (boot from user memory)
+
+Using GD-Link or J-Link
+=======================
+
+The board comes with an embedded GD-Link programmer. ``west flash`` is
+supported through pyOCD with GD-Link. The required GD32E50x CMSIS Device Family
+Pack is provided by the GigaDevice HAL module, so no extra setup is needed
+beyond installing pyOCD and connecting GD-Link.
+
+J-Link can also be used to program the board using the JTAG interface exposed in
+the JP2 header.
+
+By default, ``west flash`` and ``west debug`` use the GD-Link/pyOCD runner shown
+below. When using J-Link, select the runner explicitly:
+
+.. code-block:: console
+
+   west flash --runner jlink
+   west debug --runner jlink
+
+#. Build the Zephyr kernel and the :zephyr:code-sample:`hello_world` sample application:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: gd32e508z_eval
+      :goals: build
+      :compact:
+
+#. Run your favorite terminal program to listen for output. On Linux the
+   terminal should be something like ``/dev/ttyUSB0``. For example:
+
+   .. code-block:: console
+
+      minicom -D /dev/ttyUSB0 -o
+
+   The -o option tells minicom not to send the modem initialization
+   string. Connection should be configured as follows:
+
+      - Speed: 115200
+      - Data: 8 bits
+      - Parity: None
+      - Stop bits: 1
+
+#. To flash an image:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: gd32e508z_eval
+      :goals: flash
+      :compact:
+
+   You should see "Hello World! gd32e508z_eval" in your terminal.
+
+#. To debug an image:
+
+   .. zephyr-app-commands::
+      :zephyr-app: samples/hello_world
+      :board: gd32e508z_eval
+      :goals: debug
+      :compact:
+
+.. _GigaDevice GD32E508 Product Page:
+   https://www.gigadevice.com/product/mcu/high-performance-mcus/gd32e5xx-series/gd32e508
+
+.. _GD32E50X User Manual:
+   https://www.gd32mcu.com/download/down/document_id/249/path_type/1

--- a/boards/gd/gd32e508z_eval/gd32e508z_eval-pinctrl.dtsi
+++ b/boards/gd/gd32e508z_eval/gd32e508z_eval-pinctrl.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 GigaDevice Semiconductor Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <dt-bindings/pinctrl/gd32e508z(e)xx-pinctrl.h>
+
+&pinctrl {
+	usart0_default: usart0_default {
+		group1 {
+			pinmux = <USART0_TX_PA9_NORMP>, <USART0_RX_PA10_NORMP>;
+		};
+	};
+
+	pwm0_default: pwm0_default {
+		group1 {
+			pinmux = <TIMER0_CH0_PA8_OUT_NORMP>;
+		};
+	};
+
+	can0_default: can0_default {
+		group1 {
+			pinmux = <CAN0_RX_PD0_FRMP>, <CAN0_TX_PD1_FRMP>;
+		};
+	};
+
+	can1_default: can1_default {
+		group1 {
+			pinmux = <CAN1_RX_PB12_NORMP>, <CAN1_TX_PB13_NORMP>;
+		};
+	};
+
+	can2_default: can2_default {
+		group1 {
+			pinmux = <CAN2_RX_PE0>, <CAN2_TX_PE1>;
+		};
+	};
+};

--- a/boards/gd/gd32e508z_eval/gd32e508z_eval.dts
+++ b/boards/gd/gd32e508z_eval/gd32e508z_eval.dts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 GigaDevice Semiconductor Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <arm/gd/gd32e50x/gd32e508xe.dtsi>
+#include "gd32e508z_eval-pinctrl.dtsi"
+#include <zephyr/dt-bindings/input/input-event-codes.h>
+
+/ {
+	model = "GigaDevice GD32E508Z-EVAL";
+	compatible = "gd,gd32e508z-eval";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,console = &usart0;
+		zephyr,shell-uart = &usart0;
+		zephyr,canbus = &can0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led1: led1 {
+			gpios = <&gpiog 10 GPIO_ACTIVE_HIGH>;
+		};
+
+		led2: led2 {
+			gpios = <&gpiog 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		led3: led3 {
+			gpios = <&gpiog 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		led4: led4 {
+			gpios = <&gpiog 13 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+
+		key_a: key_a {
+			label = "KEY_A";
+			gpios = <&gpioa 0 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_A>;
+		};
+
+		key_b: key_b {
+			label = "KEY_B";
+			gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_B>;
+		};
+
+		key_c: key_c {
+			label = "KEY_C";
+			gpios = <&gpiof 13 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_C>;
+		};
+
+		key_d: key_d {
+			label = "KEY_D";
+			gpios = <&gpiof 14 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_D>;
+		};
+
+		key_cet: key_cet {
+			label = "KEY_CET";
+			gpios = <&gpiof 15 GPIO_ACTIVE_LOW>;
+			zephyr,code = <INPUT_KEY_0>;
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		/* NOTE: bridge TIMER0_CH0 (PA8) and LED1 (PG10)*/
+		pwm_led: pwm_led {
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+
+	aliases {
+		led0 = &led1;
+		sw0 = &key_a;
+		pwm-led0 = &pwm_led;
+	};
+};
+
+&gpioa {
+	status = "okay";
+};
+
+&gpioc {
+	status = "okay";
+};
+
+&gpiod {
+	status = "okay";
+};
+
+&gpioe {
+	status = "okay";
+};
+
+&gpiof {
+	status = "okay";
+};
+
+&gpiog {
+	status = "okay";
+};
+
+&usart0 {
+	status = "okay";
+	current-speed = <115200>;
+	pinctrl-0 = <&usart0_default>;
+	pinctrl-names = "default";
+};
+
+&timer0 {
+	status = "okay";
+	prescaler = <256>;
+
+	pwm0: pwm {
+		status = "okay";
+		pinctrl-0 = <&pwm0_default>;
+		pinctrl-names = "default";
+	};
+};
+
+&can0 {
+	status = "okay";
+	pinctrl-0 = <&can0_default>;
+	pinctrl-names = "default";
+	bitrate = <500000>;
+	bitrate-data = <1000000>;
+	sample-point = <800>;
+	sample-point-data = <800>;
+};

--- a/boards/gd/gd32e508z_eval/gd32e508z_eval.yaml
+++ b/boards/gd/gd32e508z_eval/gd32e508z_eval.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: gd32e508z_eval
+name: GigaDevice GD32E508Z-EVAL
+type: mcu
+arch: arm
+ram: 128
+flash: 512
+toolchain:
+  - zephyr
+  - gnuarmemb
+supported:
+  - pwm
+  - gpio
+  - counter
+  - can
+vendor: gd

--- a/boards/gd/gd32e508z_eval/gd32e508z_eval_defconfig
+++ b/boards/gd/gd32e508z_eval/gd32e508z_eval_defconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ARM_MPU=y
+CONFIG_HW_STACK_PROTECTION=y
+
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_SERIAL=y
+
+CONFIG_GPIO=y

--- a/dts/arm/gd/gd32e50x/gd32e508xe.dtsi
+++ b/dts/arm/gd/gd32e50x/gd32e508xe.dtsi
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 GigaDevice Semiconductor Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <mem.h>
+#include <arm/gd/gd32e50x/gd32e50x.dtsi>
+
+/ {
+	soc {
+		can0: can@40006400 {
+			compatible = "gd,gd32-can";
+			reg = <0x40006400 0x400>;
+			interrupts = <19 0>, <20 0>, <21 0>, <22 0>;
+			interrupt-names = "TX", "RX0", "RX1", "SCE";
+			clocks = <&cctl GD32_CLOCK_CAN0>;
+			status = "disabled";
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+		};
+
+		can1: can@40006800 {
+			compatible = "gd,gd32-can";
+			reg = <0x40006800 0x400>;
+			interrupts = <63 0>, <64 0>, <65 0>, <66 0>;
+			interrupt-names = "TX", "RX0", "RX1", "SCE";
+			clocks = <&cctl GD32_CLOCK_CAN1>;
+			master-can-reg = <0x40006400>;
+			status = "disabled";
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+		};
+
+		can2: can@4000cc00 {
+			compatible = "gd,gd32-can";
+			reg = <0x4000cc00 0x400>;
+			interrupts = <78 0>, <79 0>, <80 0>, <81 0>;
+			interrupt-names = "TX", "RX0", "RX1", "SCE";
+			clocks = <&cctl GD32_CLOCK_CAN2>;
+			master-can-reg = <0x4000cc00>;
+			status = "disabled";
+			sjw = <1>;
+			sample-point = <875>;
+			sjw-data = <1>;
+			sample-point-data = <875>;
+		};
+	};
+};
+
+&flash0 {
+	reg = <0x08000000 DT_SIZE_K(512)>;
+};
+
+&sram0 {
+	reg = <0x20000000 DT_SIZE_K(128)>;
+};

--- a/modules/hal_gigadevice/CMakeLists.txt
+++ b/modules/hal_gigadevice/CMakeLists.txt
@@ -46,6 +46,9 @@ if(${CONFIG_SOC_SERIES_GD32E50X})
   if(${CONFIG_SOC_GD32E507})
     zephyr_compile_definitions(GD32E50X_CL)
   endif()
+  if(${CONFIG_SOC_GD32E508})
+    zephyr_compile_definitions(GD32E508)
+  endif()
 endif()
 
 # GD32A50X series HAL public headers require extra definitions

--- a/soc/gd/gd32/gd32e50x/Kconfig.defconfig.gd32e508
+++ b/soc/gd/gd32/gd32e50x/Kconfig.defconfig.gd32e508
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 GigaDevice Semiconductor Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_GD32E508
+
+config SYS_CLOCK_HW_CYCLES_PER_SEC
+	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)
+
+config NUM_IRQS
+	default 88
+
+endif # SOC_GD32E508

--- a/soc/gd/gd32/gd32e50x/Kconfig.soc
+++ b/soc/gd/gd32/gd32e50x/Kconfig.soc
@@ -14,5 +14,10 @@ config SOC_GD32E507
 	bool
 	select SOC_SERIES_GD32E50X
 
+config SOC_GD32E508
+	bool
+	select SOC_SERIES_GD32E50X
+
 config SOC
 	default "gd32e507" if SOC_GD32E507
+	default "gd32e508" if SOC_GD32E508

--- a/soc/gd/gd32/soc.yml
+++ b/soc/gd/gd32/soc.yml
@@ -16,6 +16,7 @@ family:
   - name: gd32e50x
     socs:
     - name: gd32e507
+    - name: gd32e508
   - name: gd32e51x
     socs:
     - name: gd32e517


### PR DESCRIPTION
Add board and can support for gd32e508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the GigaDevice GD32E508Z-EVAL development board.
  * Enabled UART, GPIO, PWM, CAN, LEDs, and buttons.
  * Added GD32E508 SoC support with updated memory and CAN configuration.
  * Added flashing and debugging support through GD-Link and J-Link tools.

* **Documentation**
  * Added board specifications, hardware details, setup instructions, and build, flash, and debug guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->